### PR TITLE
String used as a message in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ propagate to the sender::
     actor_ref = Raiser.start()
 
     try:
-        actor_ref.ask('How are you?')
+        actor_ref.ask({'msg': 'How are you?'})
     except Exception as e:
         print(repr(e))
         # => Exception('Oops')


### PR DESCRIPTION
Changed message from `'How are you?'` to `{'msg': 'How are you?'}`.

Another place in the doc says "The message itself must always be a dict", so I'm assuming this was a mistake.
