### PR TITLE
Fix typo in future.__all__

### DIFF
--- a/pykka/future.py
+++ b/pykka/future.py
@@ -4,7 +4,7 @@ import functools
 from pykka import compat
 
 
-__all_ = [
+__all__ = [
     'Future',
     'get_all',
 ]


### PR DESCRIPTION
There's a typo in future.py.  This fixes it.