### PR TITLE
Sender functionality

### DIFF
--- a/pykka/envelope.py
+++ b/pykka/envelope.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+
+class Envelope(object):
+
+    def __init__(self, message, sender):
+        self.message = message
+        self.sender = sender


### PR DESCRIPTION
Allows a sender actor to be passed to `tell`, which can then be accessed on the receiving side as a `sender` attribute. See #40. Currently sender must be passed explicitly.

This changes the inbox to contain `Envelope`s (which is basically a wrapper for message+sender) instead of raw messages similar to Akka.
