### PR TITLE
flake8: ignore python2 compat code

### DIFF
--- a/pykka/compat.py
+++ b/pykka/compat.py
@@ -6,7 +6,7 @@ PY3 = sys.version_info[0] == 3
 if PY2:
     import Queue as queue  # noqa
 
-    string_types = basestring
+    string_types = basestring  # noqa
 
     def reraise(tp, value, tb=None):
         exec('raise tp, value, tb')


### PR DESCRIPTION
Fixes error when running flake8 in python 3.