### PR TITLE
Allow sending non-dict messages

### DIFF
--- a/pykka/actor.py
+++ b/pykka/actor.py
@@ -7,6 +7,7 @@ import uuid
 
 from pykka.envelope import Envelope
 from pykka.exceptions import ActorDeadError
+from pykka.messages import PykkaCall, PykkaGetattr, PykkaSetattr, PykkaStop
 from pykka.proxy import ActorProxy
 from pykka.registry import ActorRegistry
 
@@ -175,7 +176,7 @@ class Actor(object):
 
         It's equivalent to calling :meth:`ActorRef.stop` with ``block=False``.
         """
-        self.actor_ref.tell({'command': 'pykka_stop'})
+        self.actor_ref.tell(PykkaStop)
 
     def _stop(self):
         """
@@ -234,7 +235,7 @@ class Actor(object):
             envelope = self.actor_inbox.get()
             reply_to = getattr(envelope, 'pykka_reply_to', None)
             if reply_to:
-                if envelope.message.get('command') == 'pykka_stop':
+                if envelope.message is PykkaStop:
                     reply_to.set(None)
                 else:
                     reply_to.set_exception(ActorDeadError(
@@ -297,30 +298,26 @@ class Actor(object):
 
     def _handle_receive(self, message):
         """Handles messages sent to the actor."""
-        if message.get('command') == 'pykka_stop':
+        if message is PykkaStop:
             return self._stop()
-        if message.get('command') == 'pykka_call':
-            callee = self._get_attribute_from_path(message['attr_path'])
-            return callee(*message['args'], **message['kwargs'])
-        if message.get('command') == 'pykka_getattr':
-            attr = self._get_attribute_from_path(message['attr_path'])
+        if isinstance(message, PykkaCall):
+            callee = self._get_attribute_from_path(message.attr_path)
+            return callee(*message.args, **message.kwargs)
+        if isinstance(message, PykkaGetattr):
+            attr = self._get_attribute_from_path(message.attr_path)
             return attr
-        if message.get('command') == 'pykka_setattr':
-            parent_attr = self._get_attribute_from_path(
-                message['attr_path'][:-1])
-            attr_name = message['attr_path'][-1]
-            return setattr(parent_attr, attr_name, message['value'])
+        if isinstance(message, PykkaSetattr):
+            parent_attr = self._get_attribute_from_path(message.attr_path[:-1])
+            attr_name = message.attr_path[-1]
+            return setattr(parent_attr, attr_name, message.value)
         return self.on_receive(message)
 
     def on_receive(self, message):
         """
         May be implemented for the actor to handle regular non-proxy messages.
 
-        Messages where the value of the "command" key matches "pykka_*" are
-        reserved for internal use in Pykka.
-
         :param message: the message to handle
-        :type message: picklable dict
+        :type message: object
 
         :returns: anything that should be sent as a reply to the sender
         """
@@ -471,7 +468,7 @@ class ActorRef(object):
 
         :return: :class:`pykka.Future`, or a boolean result if blocking
         """
-        ask_future = self.ask({'command': 'pykka_stop'}, block=False)
+        ask_future = self.ask(PykkaStop, block=False)
 
         def _stop_result_converter(timeout):
             try:

--- a/pykka/envelope.py
+++ b/pykka/envelope.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+
+class Envelope(object):
+
+    def __init__(self, message, sender):
+        self.message = message
+        self.sender = sender

--- a/pykka/messages.py
+++ b/pykka/messages.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+from collections import namedtuple
+
+PykkaStop = object()
+PykkaCall = namedtuple('PykkaCall', ['attr_path', 'args', 'kwargs'])
+PykkaGetattr = namedtuple('PykkaGetattr', ['attr_path'])
+PykkaSetattr = namedtuple('PykkaSetattr', ['attr_path', 'value'])

--- a/tests/actor_test.py
+++ b/tests/actor_test.py
@@ -3,6 +3,7 @@ import unittest
 import uuid
 
 from pykka import ActorDeadError, ActorRegistry, ThreadingActor
+from pykka.messages import PykkaStop
 
 
 class AnActor(object):
@@ -142,7 +143,7 @@ class ActorTest(object):
         event = self.event_class()
         self.actor_ref.tell({'command': 'callback', 'callback': event.wait})
         self.actor_ref.stop(block=False)
-        response = self.actor_ref.ask({'command': 'pykka_stop'}, block=False)
+        response = self.actor_ref.ask(PykkaStop, block=False)
         event.set()
 
         response.get(timeout=0.5)


### PR DESCRIPTION
Removes the rest of the internal dependency on dict type messages. It does so by changing the  'pykka_*' command values to specific objects, which I think makes it much clearer what is expected and being passed, and that it is for internal use.

Note: this PR depends on and is branched of #55