### PR TITLE
using the mock module if available (py 3.3)

### DIFF
--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -1,6 +1,9 @@
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from pykka import ActorRegistry, ThreadingActor
 


### PR DESCRIPTION
Just a small patch. The mock module is included since 3.3.
https://docs.python.org/3/library/unittest.mock.html