### PR TITLE
Change logging level of uncaught exceptions in actors to logging.INFO

### DIFF
--- a/pykka/actor.py
+++ b/pykka/actor.py
@@ -203,7 +203,7 @@ class Actor(object):
                     reply_to.set(response)
             except Exception:
                 if reply_to:
-                    logger.debug(
+                    logger.info(
                         'Exception returned from %s to caller:' % self,
                         exc_info=sys.exc_info())
                     reply_to.set_exception()


### PR DESCRIPTION
Hy Jodal!

I have been battling with the problem of uncaught exceptions in the future proxy, and the silent fail that this often results in. It is a real problem to me, since it often results in very strange bugs as a result of simple syntax errors. I haven't been able to figure out a good solution (i.e. a suitable error handling framework for Actors in an OO setting), however at least I have a simple mitigation:

Change the log level in actor.py:203 from logging.DEBUG to logging.INFO.

The point is that log level INFO isn't used anywhere else in pykka, so this allows you to set the logging level of the pykka module below the chatty DEBUG level, to a level that only logs uncaught exceptions (i.e. usually it will log nothing in pykka, unless an uncaught exception is thrown in an actor). The levels WARNING and ERROR can remain for internal problems in the pykka framework.

I would suggest that you add at a prominent place a recommendation in the documentation:

import logging
logging.basicConfig()
logging.getLogger('pykka').setLevel(logging.INFO)

This has saved me from a lot of heartache once I figured it out!