### PR TITLE
allow futures to be awaited and yielded from

### DIFF
--- a/pykka/compat/__init__.py
+++ b/pykka/compat/__init__.py
@@ -2,6 +2,7 @@ import sys
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
+GT_PY34 = sys.version_info > (3, 4)
 
 if PY2:
     import Queue as queue  # noqa
@@ -25,3 +26,21 @@ else:
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)
         raise value
+
+
+if PY3:
+
+    # Return inside a generator is a syntax error on python2
+    # so we need to dynamically load it
+    from pykka.compat.await_dunder_future_py3 import await_dunder_future  # noqa
+
+else:
+
+    await_dunder_future = None
+
+
+if GT_PY34:
+    from pykka.compat.await_keyword_py3 import await_keyword  # noqa
+else:
+
+    await_keyword = None

--- a/pykka/compat/await_dunder_future_py3.py
+++ b/pykka/compat/await_dunder_future_py3.py
@@ -1,0 +1,4 @@
+def await_dunder_future(self):
+    yield
+    value = self.get()
+    return value

--- a/pykka/compat/await_keyword_py3.py
+++ b/pykka/compat/await_keyword_py3.py
@@ -1,0 +1,2 @@
+async def await_keyword(val):
+    return await val

--- a/pykka/future.py
+++ b/pykka/future.py
@@ -1,5 +1,7 @@
 import functools
 
+from pykka import compat
+
 
 __all__ = ['Future', 'get_all']
 
@@ -237,6 +239,9 @@ class Future(object):
             lambda timeout: functools.reduce(func, self.get(timeout), *args)
         )
         return future
+
+    __await__ = compat.await_dunder_future
+    __iter__ = __await__
 
 
 def get_all(futures, timeout=None):

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -8,16 +8,6 @@ from pykka import Future, Timeout, get_all
 from tests import has_gevent
 
 
-@pytest.fixture
-def future(runtime):
-    return runtime.future_class()
-
-
-@pytest.fixture
-def futures(runtime):
-    return [runtime.future_class() for _ in range(3)]
-
-
 def test_base_future_get_is_not_implemented():
     future = Future()
 

--- a/tests/test_future_py3.py
+++ b/tests/test_future_py3.py
@@ -1,0 +1,34 @@
+import pytest
+
+import asyncio
+import sys
+
+from pykka.compat import await_keyword
+
+
+def run_async(coroutine):
+    loop = asyncio.get_event_loop()
+    f = asyncio.ensure_future(coroutine, loop=loop)
+    return loop.run_until_complete(f)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 5), reason='await requires Python 3.5+'
+)
+def test_future_supports_await_syntax(future):
+    @asyncio.coroutine
+    def get_value():
+        return await_keyword(future)
+
+    future.set(1)
+    assert run_async(get_value()) == 1
+
+
+def test_future_supports_yield_from_syntax(future):
+    @asyncio.coroutine
+    def get_value():
+        val = yield from future
+        return val
+
+    future.set(1)
+    assert run_async(get_value()) == 1


### PR DESCRIPTION
Currently Pykka futures are not compatible with the `await` and `yield from` syntax. This PR simply adds that capability by implementing `__await__` and `__iter__` on the base Future class