### PR TITLE
Use namedtuples for internal message objects

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -128,6 +128,9 @@ Internals
 
 - Format code with Black.
 
+- Change internal messaging format from ``dict`` to ``namedtuple``. (PR:
+  :issue:`80`)
+
 
 v1.2.1 (2015-07-20)
 ===================

--- a/pykka/actor.py
+++ b/pykka/actor.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import uuid
 
+from pykka import messaging
 from pykka.exceptions import ActorDeadError
 from pykka.ref import ActorRef
 from pykka.registry import ActorRegistry
@@ -164,7 +165,7 @@ class Actor(object):
 
         It's equivalent to calling :meth:`ActorRef.stop` with ``block=False``.
         """
-        self.actor_ref.tell({'command': 'pykka_stop'})
+        self.actor_ref.tell(messaging.ActorStop())
 
     def _stop(self):
         """
@@ -221,10 +222,7 @@ class Actor(object):
         while not self.actor_inbox.empty():
             envelope = self.actor_inbox.get()
             if envelope.reply_to is not None:
-                if (
-                    isinstance(envelope.message, dict)
-                    and envelope.message.get('command') == 'pykka_stop'
-                ):
+                if isinstance(envelope.message, messaging.ActorStop):
                     envelope.reply_to.set(None)
                 else:
                     envelope.reply_to.set_exception(
@@ -296,32 +294,24 @@ class Actor(object):
 
     def _handle_receive(self, message):
         """Handles messages sent to the actor."""
-        if isinstance(message, dict) and message.get('command', '').startswith(
-            'pykka_'
-        ):
-            command = message['command']
-            if command == 'pykka_stop':
-                return self._stop()
-            if command == 'pykka_call':
-                callee = self._get_attribute_from_path(message['attr_path'])
-                return callee(*message['args'], **message['kwargs'])
-            if command == 'pykka_getattr':
-                attr = self._get_attribute_from_path(message['attr_path'])
-                return attr
-            if command == 'pykka_setattr':
-                parent_attr = self._get_attribute_from_path(
-                    message['attr_path'][:-1]
-                )
-                attr_name = message['attr_path'][-1]
-                return setattr(parent_attr, attr_name, message['value'])
+        # TODO Handle old dict format too, but emit DeprecationWarning
+        if isinstance(message, messaging.ActorStop):
+            return self._stop()
+        if isinstance(message, messaging.ProxyCall):
+            callee = self._get_attribute_from_path(message.attr_path)
+            return callee(*message.args, **message.kwargs)
+        if isinstance(message, messaging.ProxyGetAttr):
+            attr = self._get_attribute_from_path(message.attr_path)
+            return attr
+        if isinstance(message, messaging.ProxySetAttr):
+            parent_attr = self._get_attribute_from_path(message.attr_path[:-1])
+            attr_name = message.attr_path[-1]
+            return setattr(parent_attr, attr_name, message.value)
         return self.on_receive(message)
 
     def on_receive(self, message):
         """
         May be implemented for the actor to handle regular non-proxy messages.
-
-        Messages where the value of the "command" key matches "pykka_*" are
-        reserved for internal use in Pykka.
 
         :param message: the message to handle
         :type message: any

--- a/pykka/actor.py
+++ b/pykka/actor.py
@@ -294,7 +294,7 @@ class Actor(object):
 
     def _handle_receive(self, message):
         """Handles messages sent to the actor."""
-        # TODO Handle old dict format too, but emit DeprecationWarning
+        message = messaging.upgrade_internal_message(message)
         if isinstance(message, messaging.ActorStop):
             return self._stop()
         if isinstance(message, messaging.ProxyCall):

--- a/pykka/messaging.py
+++ b/pykka/messaging.py
@@ -1,3 +1,6 @@
+from collections import namedtuple
+
+
 class Envelope(object):
     """
     Envelope to add metadata to a message.
@@ -21,3 +24,12 @@ class Envelope(object):
         return 'Envelope(message={!r}, reply_to={!r})'.format(
             self.message, self.reply_to
         )
+
+
+# Internal actor messages
+ActorStop = namedtuple('ActorStop', [])
+
+# Internal proxy messages
+ProxyCall = namedtuple('ProxyCall', ['attr_path', 'args', 'kwargs'])
+ProxyGetAttr = namedtuple('ProxyGetAttr', ['attr_path'])
+ProxySetAttr = namedtuple('ProxySetAttr', ['attr_path', 'value'])

--- a/pykka/messaging.py
+++ b/pykka/messaging.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import namedtuple
 
 
@@ -33,3 +34,41 @@ ActorStop = namedtuple('ActorStop', [])
 ProxyCall = namedtuple('ProxyCall', ['attr_path', 'args', 'kwargs'])
 ProxyGetAttr = namedtuple('ProxyGetAttr', ['attr_path'])
 ProxySetAttr = namedtuple('ProxySetAttr', ['attr_path', 'value'])
+
+
+def upgrade_internal_message(message):
+    """Filter that upgrades dict-based internal messages to the new format.
+
+    This is needed for a transitional period because Mopidy < 3 uses
+    the old internal message format directly, and maybe others.
+    """
+
+    if not isinstance(message, dict):
+        return message
+    if not message.get('command', '').startswith('pykka_'):
+        return message
+
+    warnings.warn(
+        'Pykka received a dict-based internal message. '
+        'This is deprecated and will be unsupported in the future. '
+        'Message: {!r}'.format(message),
+        DeprecationWarning,
+    )
+
+    command = message.get('command')
+    if command == 'pykka_stop':
+        return ActorStop()
+    elif command == 'pykka_call':
+        return ProxyCall(
+            attr_path=message['attr_path'],
+            args=message['args'],
+            kwargs=message['kwargs'],
+        )
+    elif command == 'pykka_getattr':
+        return ProxyGetAttr(attr_path=message['attr_path'])
+    elif command == 'pykka_setattr':
+        return ProxySetAttr(
+            attr_path=message['attr_path'], value=message['value']
+        )
+    else:
+        raise ValueError('Unknown internal message: {!r}'.format(message))

--- a/pykka/ref.py
+++ b/pykka/ref.py
@@ -1,5 +1,5 @@
 from pykka.exceptions import ActorDeadError
-from pykka.messaging import Envelope
+from pykka.messaging import ActorStop, Envelope
 from pykka.proxy import ActorProxy
 
 
@@ -135,7 +135,7 @@ class ActorRef(object):
 
         :return: :class:`pykka.Future`, or a boolean result if blocking
         """
-        ask_future = self.ask({'command': 'pykka_stop'}, block=False)
+        ask_future = self.ask(ActorStop(), block=False)
 
         def _stop_result_converter(timeout):
             try:

--- a/tests/proxy/test_legacy_message_format.py
+++ b/tests/proxy/test_legacy_message_format.py
@@ -1,0 +1,53 @@
+import pytest
+
+
+@pytest.fixture(scope='module')
+def actor_class(runtime):
+    class ActorA(runtime.actor_class):
+        an_attr = 'a value'
+
+        def a_method(self):
+            return 'a return value'
+
+    return ActorA
+
+
+@pytest.fixture
+def actor_ref(actor_class):
+    actor_ref = actor_class.start()
+    yield actor_ref
+    actor_ref.stop()
+
+
+def test_proxy_call_via_legacy_message(actor_ref):
+    with pytest.deprecated_call():
+        result = actor_ref.ask(
+            {
+                'command': 'pykka_call',
+                'attr_path': ['a_method'],
+                'args': [],
+                'kwargs': {},
+            }
+        )
+
+    assert result == 'a return value'
+
+
+def test_proxy_attr_via_legacy_message(actor_ref):
+    with pytest.deprecated_call():
+        result_before = actor_ref.ask(
+            {'command': 'pykka_getattr', 'attr_path': ['an_attr']}
+        )
+        actor_ref.tell(
+            {
+                'command': 'pykka_setattr',
+                'attr_path': ['an_attr'],
+                'value': 'new value',
+            }
+        )
+        result_after = actor_ref.ask(
+            {'command': 'pykka_getattr', 'attr_path': ['an_attr']}
+        )
+
+    assert result_before == 'a value'
+    assert result_after == 'new value'

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,7 +1,58 @@
-from pykka.messaging import Envelope
+import warnings
+
+import pytest
+
+from pykka.messaging import (
+    ActorStop,
+    Envelope,
+    ProxyCall,
+    ProxyGetAttr,
+    ProxySetAttr,
+    upgrade_internal_message,
+)
 
 
 def test_envelope_repr():
     envelope = Envelope('message', reply_to=123)
 
     assert repr(envelope) == "Envelope(message='message', reply_to=123)"
+
+
+@pytest.mark.parametrize(
+    'old_format, new_format',
+    [
+        ({'command': 'pykka_stop'}, ActorStop()),
+        (
+            {
+                'command': 'pykka_call',
+                'attr_path': ['nested', 'method'],
+                'args': [1],
+                'kwargs': {'a': 'b'},
+            },
+            ProxyCall(
+                attr_path=['nested', 'method'], args=[1], kwargs={'a': 'b'}
+            ),
+        ),
+        (
+            {'command': 'pykka_getattr', 'attr_path': ['nested', 'attr']},
+            ProxyGetAttr(attr_path=['nested', 'attr']),
+        ),
+        (
+            {
+                'command': 'pykka_setattr',
+                'attr_path': ['nested', 'attr'],
+                'value': 'abcdef',
+            },
+            ProxySetAttr(attr_path=['nested', 'attr'], value='abcdef'),
+        ),
+    ],
+)
+def test_upgrade_internal_message(old_format, new_format):
+    with warnings.catch_warnings(record=True) as w:
+        assert upgrade_internal_message(old_format) == new_format
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert 'Pykka received a dict-based internal message.' in str(
+            w[0].message
+        )


### PR DESCRIPTION
This is a purely internal change.

Mopidy < 3 is known to depend on the details of the old internal messaging format, so a message filter is added to upgrade any messages in the old format to the new format, while emitting a `DeprecationWarning`.