### PR TITLE
proxy: Add pykka.traversable() marker

### DIFF
--- a/docs/api/proxies.rst
+++ b/docs/api/proxies.rst
@@ -9,3 +9,5 @@ Proxies
     :members:
 
     .. automethod:: __call__
+
+.. autofunction:: pykka.traversable

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -62,6 +62,13 @@ Proxies
   proxy with :meth:`~pykka.ActorRef.tell` semantics. (Contributed by Andrey
   Gubarev. Fixes: :issue:`63`. PR: :issue:`72`)
 
+- Add :func:`~pykka.traversable` for marking an actor's attributes as
+  traversable when used through actor proxies. The old way of manually adding
+  a ``pykka_traversable`` attribute to the object to be traversed still works,
+  but the new function is recommended as it provides protection against typos
+  in the marker name, and keeps the traversable marking in the actor class
+  itself. (PR: :issue:`81`)
+
 Futures
 -------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -291,19 +291,16 @@ through a proxy. For this case, Pykka supports "traversable attributes". By
 marking an actor attribute as traversable, Pykka will not return the attribute
 when accessed, but wrap it in a new proxy which is returned instead.
 
-To mark an attribute as traversable, simply set the ``pykka_traversable``
-attribute to :class:`True`::
+To mark an attribute as traversable, simply mark it with the
+:func:`~pykka.traversable` function::
 
     import pykka
 
     class AnActor(pykka.ThreadingActor):
-        playback = Playback()
+        playback = pykka.traversable(Playback())
 
     class Playback(object):
-        pykka_traversable = True
-
         def play(self):
-            # ...
             return True
 
     proxy = AnActor.start().proxy()

--- a/pykka/__init__.py
+++ b/pykka/__init__.py
@@ -1,7 +1,7 @@
 from pykka.actor import Actor
 from pykka.exceptions import ActorDeadError, Timeout
 from pykka.future import Future, get_all
-from pykka.proxy import ActorProxy, CallableProxy
+from pykka.proxy import ActorProxy, CallableProxy, traversable
 from pykka.ref import ActorRef
 from pykka.registry import ActorRegistry
 from pykka.threading import ThreadingActor, ThreadingFuture
@@ -19,6 +19,7 @@ __all__ = [
     'ThreadingFuture',
     'Timeout',
     'get_all',
+    'traversable',
 ]
 
 

--- a/tests/proxy/test_proxy.py
+++ b/tests/proxy/test_proxy.py
@@ -1,16 +1,17 @@
 import pytest
 
+import pykka
 from pykka import ActorDeadError, ActorProxy
 
 
 class NestedObject(object):
-    pykka_traversable = True
+    pass
 
 
 @pytest.fixture(scope='module')
 def actor_class(runtime):
     class ActorForProxying(runtime.actor_class):
-        a_nested_object = NestedObject()
+        a_nested_object = pykka.traversable(NestedObject())
         a_class_attr = 'class_attr'
 
         def __init__(self):


### PR DESCRIPTION
Add `pykka.traversable` for marking an actor's attributes as traversable when used through actor proxies.

The old way of manually adding a `pykka_traversable` attribute to the object to be traversed still works, but the new function is recommended as it provides protection against typos in the marker name, and keeps the traversable marking in the actor class itself.