### PR TITLE
Remove Python 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - py35
       - py36
       - py37
       - py38
@@ -48,11 +47,6 @@ jobs:
       - store_test_results:
           path: test-results
 
-  py35:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.5
-
   py36:
     <<: *test-template
     docker:
@@ -66,7 +60,7 @@ jobs:
   pypy3:
     <<: *test-template
     docker:
-      - image: pypy:3.5
+      - image: pypy:3.6
 
   black: *test-template
 
@@ -75,4 +69,3 @@ jobs:
   docs: *test-template
 
   flake8: *test-template
-

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,8 @@ Pykka is available from PyPI. To install it, run::
 
     pip install pykka
 
-Pykka works with CPython 3.5+ and PyPy 3.5+.
+Pykka works with CPython 3.6+ and PyPy 3.6+. If you need support for Python
+2.7 or 3.5, you can use Pykka 2.x.
 
 
 License

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,8 @@ v3.0.0 (UNRELEASED)
 
 - Remove support for Python 2.7. (PR: :issue:`87`)
 
+- Remove support for Python 3.5. (PR: :issue:`89`)
+
 - Remove support for automatically upgrading the internal message format used
   by Pykka 1.x to the message types used by Pykka 2+. (PR: :issue:`88`)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,8 @@ Pykka is available from PyPI. To install it, run::
 
     pip install pykka
 
-Pykka works with CPython 3.5+ and PyPy 3.5+.
+Pykka works with CPython 3.6+ and PyPy 3.6+. If you need support for Python
+2.7 or 3.5, you can use Pykka 2.x.
 
 
 .. toctree::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -57,7 +57,7 @@ Pykka's actor API comes with the following implementations:
 - Eventlet: Each :class:`~pykka.eventlet.EventletActor` is executed by an
   `Eventlet  <https://eventlet.net/>`_ greenlet.
 
-Pykka has an extensive test suite, and is tested on CPython 3.5+
+Pykka has an extensive test suite, and is tested on CPython 3.6+
 as well as PyPy.
 
 

--- a/examples/deadlock_debugging.py
+++ b/examples/deadlock_debugging.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
     pid = os.getpid()
     print("Making main thread relax; not block, not quit")
-    print("1) Use `kill -SIGUSR1 {:d}` to log thread tracebacks".format(pid))
-    print("2) Then `kill {:d}` to terminate the process".format(pid))
+    print(f"1) Use `kill -SIGUSR1 {pid:d}` to log thread tracebacks")
+    print(f"2) Then `kill {pid:d}` to terminate the process")
     while True:
         time.sleep(1)

--- a/pykka/_actor.py
+++ b/pykka/_actor.py
@@ -92,7 +92,7 @@ class Actor:
             "Did you forget to call super() in your override?"
         )
         ActorRegistry.register(obj.actor_ref)
-        logger.debug("Starting {}".format(obj))
+        logger.debug(f"Starting {obj}")
         obj._start_actor_loop()
         return obj.actor_ref
 
@@ -152,7 +152,7 @@ class Actor:
         self.actor_ref = ActorRef(self)
 
     def __str__(self):
-        return "{} ({})".format(self.__class__.__name__, self.actor_urn)
+        return f"{self.__class__.__name__} ({self.actor_urn})"
 
     def stop(self):
         """
@@ -168,7 +168,7 @@ class Actor:
         """
         ActorRegistry.unregister(self.actor_ref)
         self.actor_stopped.set()
-        logger.debug("Stopped {}".format(self))
+        logger.debug(f"Stopped {self}")
         try:
             self.on_stop()
         except Exception:
@@ -194,7 +194,7 @@ class Actor:
             except Exception:
                 if envelope.reply_to is not None:
                     logger.info(
-                        "Exception returned from {} to caller:".format(self),
+                        f"Exception returned from {self} to caller:",
                         exc_info=sys.exc_info(),
                     )
                     envelope.reply_to.set_exception()
@@ -207,9 +207,7 @@ class Actor:
             except BaseException:
                 exception_value = sys.exc_info()[1]
                 logger.debug(
-                    "{!r} in {}. Stopping all actors.".format(
-                        exception_value, self
-                    )
+                    f"{exception_value!r} in {self}. Stopping all actors."
                 )
                 self._stop()
                 ActorRegistry.stop_all()
@@ -224,9 +222,8 @@ class Actor:
                         exc_info=(
                             ActorDeadError,
                             ActorDeadError(
-                                "{} stopped before handling the message".format(
-                                    self.actor_ref
-                                )
+                                f"{self.actor_ref} stopped before "
+                                f"handling the message"
                             ),
                             None,
                         )
@@ -265,7 +262,7 @@ class Actor:
     def _handle_failure(self, exception_type, exception_value, traceback):
         """Logs unexpected failures, unregisters and stops the actor."""
         logger.error(
-            "Unhandled exception in {}:".format(self),
+            f"Unhandled exception in {self}:",
             exc_info=(exception_type, exception_value, traceback),
         )
         ActorRegistry.unregister(self.actor_ref)
@@ -312,9 +309,7 @@ class Actor:
 
         :returns: anything that should be sent as a reply to the sender
         """
-        logger.warning(
-            "Unexpected message received by {}: {}".format(self, message)
-        )
+        logger.warning(f"Unexpected message received by {self}: {message}")
 
     def _get_attribute_from_path(self, attr_path):
         """
@@ -338,9 +333,8 @@ class Actor:
             return parent_attrs[attr_name]
         except KeyError:
             raise AttributeError(
-                "type object {!r} has no attribute {!r}".format(
-                    parent.__class__.__name__, attr_name
-                )
+                f"type object {parent.__class__.__name__!r} "
+                f"has no attribute {attr_name!r}"
             )
 
     def _introspect_attributes(self, obj):

--- a/pykka/_envelope.py
+++ b/pykka/_envelope.py
@@ -18,6 +18,4 @@ class Envelope:
         self.reply_to = reply_to
 
     def __repr__(self):
-        return "Envelope(message={!r}, reply_to={!r})".format(
-            self.message, self.reply_to
-        )
+        return f"Envelope(message={self.message!r}, reply_to={self.reply_to!r})"

--- a/pykka/_future.py
+++ b/pykka/_future.py
@@ -11,8 +11,8 @@ class Future:
 
     Typically returned by calls to actor methods or accesses to actor fields.
 
-    To get hold of the encapsulated value, call :meth:`Future.get` or, if
-    using Python 3.5+, ``await`` the future.
+    To get hold of the encapsulated value, call :meth:`Future.get` or
+    ``await`` the future.
     """
 
     def __init__(self):

--- a/pykka/_proxy.py
+++ b/pykka/_proxy.py
@@ -112,7 +112,7 @@ class ActorProxy:
 
     def __init__(self, actor_ref, attr_path=None):
         if not actor_ref.is_alive():
-            raise ActorDeadError("{} not found".format(actor_ref))
+            raise ActorDeadError(f"{actor_ref} not found")
         self.actor_ref = actor_ref
         self._actor = actor_ref._actor
         self._attr_path = attr_path or tuple()
@@ -136,10 +136,10 @@ class ActorProxy:
             if self._is_self_proxy(attr):
                 logger.warning(
                     (
-                        "{} attribute {!r} is a proxy to itself. "
-                        "Consider making it private by renaming it to {!r}."
-                    ).format(
-                        self._actor, ".".join(attr_path), "_" + attr_path[-1]
+                        f"{self._actor} attribute {'.'.join(attr_path)!r} "
+                        f"is a proxy to itself. "
+                        f"Consider making it private "
+                        f"by renaming it to {'_' + attr_path[-1]!r}."
                     )
                 )
                 continue
@@ -194,8 +194,8 @@ class ActorProxy:
         return hash((self._actor, self._attr_path))
 
     def __repr__(self):
-        return "<ActorProxy for {}, attr_path={!r}>".format(
-            self.actor_ref, self._attr_path
+        return (
+            f"<ActorProxy for {self.actor_ref}, attr_path={self._attr_path!r}>"
         )
 
     def __dir__(self):
@@ -214,7 +214,7 @@ class ActorProxy:
 
         attr_info = self._known_attrs.get(attr_path)
         if attr_info is None:
-            raise AttributeError("{} has no attribute {!r}".format(self, name))
+            raise AttributeError(f"{self} has no attribute {name!r}")
 
         if attr_info["callable"]:
             if attr_path not in self._callable_proxies:

--- a/pykka/_proxy.py
+++ b/pykka/_proxy.py
@@ -49,8 +49,7 @@ class ActorProxy:
 
         actor_proxy.method_with_side_effect().get()
 
-    If you're using Python 3.5+, you can also use the ``await`` keyword to
-    block until the method completes::
+    You can also use the ``await`` keyword to block until the method completes::
 
         await actor_proxy.method_with_side_effect()
 

--- a/pykka/_ref.py
+++ b/pykka/_ref.py
@@ -38,10 +38,10 @@ class ActorRef:
         self.actor_stopped = actor.actor_stopped
 
     def __repr__(self):
-        return "<ActorRef for {}>".format(self)
+        return f"<ActorRef for {self}>"
 
     def __str__(self):
-        return "{} ({})".format(self.actor_class.__name__, self.actor_urn)
+        return f"{self.actor_class.__name__} ({self.actor_urn})"
 
     def is_alive(self):
         """
@@ -70,7 +70,7 @@ class ActorRef:
         :return: nothing
         """
         if not self.is_alive():
-            raise ActorDeadError("{} not found".format(self))
+            raise ActorDeadError(f"{self} not found")
         self.actor_inbox.put(Envelope(message))
 
     def ask(self, message, block=True, timeout=None):
@@ -104,7 +104,7 @@ class ActorRef:
 
         try:
             if not self.is_alive():
-                raise ActorDeadError("{} not found".format(self))
+                raise ActorDeadError(f"{self} not found")
         except ActorDeadError:
             future.set_exception()
         else:

--- a/pykka/_registry.py
+++ b/pykka/_registry.py
@@ -117,7 +117,7 @@ class ActorRegistry:
         """
         with cls._actor_refs_lock:
             cls._actor_refs.append(actor_ref)
-        logger.debug("Registered {}".format(actor_ref))
+        logger.debug(f"Registered {actor_ref}")
 
     @classmethod
     def stop_all(cls, block=True, timeout=None):
@@ -161,8 +161,6 @@ class ActorRegistry:
                 cls._actor_refs.remove(actor_ref)
                 removed = True
         if removed:
-            logger.debug("Unregistered {}".format(actor_ref))
+            logger.debug(f"Unregistered {actor_ref}")
         else:
-            logger.debug(
-                "Unregistered {} (not found in registry)".format(actor_ref)
-            )
+            logger.debug(f"Unregistered {actor_ref} (not found in registry)")

--- a/pykka/_threading.py
+++ b/pykka/_threading.py
@@ -50,7 +50,7 @@ class ThreadingFuture(Future):
             else:
                 return self._data["value"]
         except queue.Empty:
-            raise Timeout("{} seconds".format(timeout))
+            raise Timeout(f"{timeout} seconds")
 
     def set(self, value=None):
         self._queue.put({"value": value}, block=False)

--- a/pykka/debug.py
+++ b/pykka/debug.py
@@ -60,6 +60,4 @@ def log_thread_tracebacks(*args, **kwargs):
     for ident, frame in sys._current_frames().items():
         name = thread_names.get(ident, "?")
         stack = "".join(traceback.format_stack(frame))
-        logger.critical(
-            "Current state of {} (ident: {}):\n{}".format(name, ident, stack)
-        )
+        logger.critical(f"Current state of {name} (ident: {ident}):\n{stack}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = ["setuptools", "wheel"]
 
 [tool.black]
-target-version = ["py35", "py36", "py37", "py38"]
+target-version = ["py36", "py37", "py38"]
 line-length = 80

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
    Topic :: Software Development :: Libraries
    License :: OSI Approved :: Apache Software License
    Programming Language :: Python :: 3
-   Programming Language :: Python :: 3.5
    Programming Language :: Python :: 3.6
    Programming Language :: Python :: 3.7
    Programming Language :: Python :: 3.8
@@ -29,7 +28,7 @@ classifiers =
 zip_safe = True
 include_package_data = False
 packages = find:
-python_requires = >= 3.5
+python_requires = >= 3.6
 install_requires =
     setuptools
 

--- a/tests/log_handler.py
+++ b/tests/log_handler.py
@@ -35,4 +35,4 @@ class PykkaTestLogHandler(logging.Handler):
                     return
                 self.events[level].clear()
             self.events[level].wait(1)
-        raise Exception("Timeout: Waited {:d}s for log message".format(timeout))
+        raise Exception(f"Timeout: Waited {timeout:d}s for log message")

--- a/tests/performance.py
+++ b/tests/performance.py
@@ -6,7 +6,8 @@ from pykka import ActorRegistry, ThreadingActor
 def time_it(func):
     start = time.time()
     func()
-    print("{!r} took {:.3f}s".format(func.__name__, time.time() - start))
+    elapsed = time.time() - start
+    print(f"{func.__name__!r} took {elapsed:.3f}s")
 
 
 class SomeObject:

--- a/tests/proxy/test_proxy.py
+++ b/tests/proxy/test_proxy.py
@@ -112,7 +112,7 @@ def test_proxy_constructor_raises_exception_if_actor_is_dead(actor_class):
     with pytest.raises(ActorDeadError) as exc_info:
         ActorProxy(actor_ref)
 
-    assert str(exc_info.value) == "{} not found".format(actor_ref)
+    assert str(exc_info.value) == f"{actor_ref} not found"
 
 
 def test_actor_ref_may_be_retrieved_from_proxy_if_actor_is_dead(proxy):

--- a/tests/proxy/test_static_method_calls.py
+++ b/tests/proxy/test_static_method_calls.py
@@ -17,7 +17,7 @@ def actor_class(runtime):
             self.events.on_failure_was_called.set()
 
         def functional_hello(self, s):
-            return "Hello, {}!".format(s)
+            return f"Hello, {s}!"
 
         def set_cat(self, s):
             self.cat = s

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -56,7 +56,7 @@ def test_unexpected_messages_are_logged(actor_ref, log_handler):
         log_record = log_handler.messages["warning"][0]
 
     assert log_record.getMessage().split(": ")[0] == (
-        "Unexpected message received by {}".format(actor_ref)
+        f"Unexpected message received by {actor_ref}"
     )
 
 
@@ -70,7 +70,7 @@ def test_exception_is_logged_when_returned_to_caller(actor_ref, log_handler):
         log_record = log_handler.messages["info"][0]
 
     assert log_record.getMessage() == (
-        "Exception returned from {} to caller:".format(actor_ref)
+        f"Exception returned from {actor_ref} to caller:"
     )
     assert log_record.exc_info[0] == Exception
     assert str(log_record.exc_info[1]) == "foo"
@@ -90,9 +90,7 @@ def test_exception_is_logged_when_not_reply_requested(
         assert len(log_handler.messages["error"]) == 1
         log_record = log_handler.messages["error"][0]
 
-    assert log_record.getMessage() == "Unhandled exception in {}:".format(
-        actor_ref
-    )
+    assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"
     assert log_record.exc_info[0] == Exception
     assert str(log_record.exc_info[1]) == "foo"
 
@@ -111,7 +109,7 @@ def test_base_exception_is_logged(actor_ref, events, log_handler):
         log_record = log_handler.messages["debug"][0]
 
     assert log_record.getMessage() == (
-        "BaseException() in {}. Stopping all actors.".format(actor_ref)
+        f"BaseException() in {actor_ref}. Stopping all actors."
     )
 
 
@@ -127,9 +125,7 @@ def test_exception_in_on_start_is_logged(
         assert len(log_handler.messages["error"]) == 1
         log_record = log_handler.messages["error"][0]
 
-    assert log_record.getMessage() == "Unhandled exception in {}:".format(
-        actor_ref
-    )
+    assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"
 
 
 def test_exception_in_on_stop_is_logged(
@@ -144,9 +140,7 @@ def test_exception_in_on_stop_is_logged(
         assert len(log_handler.messages["error"]) == 1
         log_record = log_handler.messages["error"][0]
 
-    assert log_record.getMessage() == "Unhandled exception in {}:".format(
-        actor_ref
-    )
+    assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"
 
 
 def test_exception_in_on_failure_is_logged(
@@ -162,6 +156,4 @@ def test_exception_in_on_failure_is_logged(
         assert len(log_handler.messages["error"]) == 2
         log_record = log_handler.messages["error"][0]
 
-    assert log_record.getMessage() == "Unhandled exception in {}:".format(
-        actor_ref
-    )
+    assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -113,7 +113,7 @@ def test_tell_fails_if_actor_is_stopped(actor_ref):
     with pytest.raises(ActorDeadError) as exc_info:
         actor_ref.tell({"command": "a custom message"})
 
-    assert str(exc_info.value) == "{} not found".format(actor_ref)
+    assert str(exc_info.value) == f"{actor_ref} not found"
 
 
 def test_ask_blocks_until_response_arrives(actor_ref):
@@ -139,7 +139,7 @@ def test_ask_fails_if_actor_is_stopped(actor_ref):
     with pytest.raises(ActorDeadError) as exc_info:
         actor_ref.ask({"command": "ping"})
 
-    assert str(exc_info.value) == "{} not found".format(actor_ref)
+    assert str(exc_info.value) == f"{actor_ref} not found"
 
 
 def test_ask_nonblocking_fails_future_if_actor_is_stopped(actor_ref):
@@ -149,4 +149,4 @@ def test_ask_nonblocking_fails_future_if_actor_is_stopped(actor_ref):
     with pytest.raises(ActorDeadError) as exc_info:
         future.get()
 
-    assert str(exc_info.value) == "{} not found".format(actor_ref)
+    assert str(exc_info.value) == f"{actor_ref} not found"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py35, py36, py37, py38, pypy3,
+    py36, py37, py38, pypy3,
     black, check-manifest, docs, flake8
 
 [testenv]
@@ -30,4 +30,3 @@ commands = python -m sphinx -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 [testenv:flake8]
 deps = .[lint]
 commands = python -m flake8
-


### PR DESCRIPTION
Python 3.5 was released in September 2015, thus it does not reach end-of-life before September 2020.

My main motivation for removing support for Python 3.5 before it reaches end-of-life is to be able to use some of the typing improvements in Python 3.6, e.g. `typing.NamedTuple` and PEP 526 syntax for variable type annotations.