### PR TITLE
Eventlet event fixes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,10 @@ v3.0.0 (UNRELEASED)
 - Remove support for automatically upgrading the internal message format used
   by Pykka 1.x to the message types used by Pykka 2+. (PR: :issue:`88`)
 
+- Remove ``isSet()`` method from :class:`~pykka.eventlet.EventletEvent`, as
+  this method is not part of the :class:`~threading.Event` API in Python 3.
+  (PR: :issue:`91`)
+
 
 v2.0.2 (2019-12-02)
 ===================

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,11 @@ v3.0.0 (UNRELEASED)
   this method is not part of the :class:`~threading.Event` API in Python 3.
   (PR: :issue:`91`)
 
+- Add missing :class:`None` default value for the ``timeout`` keyword argument to
+  :meth:`~pykka.eventlet.EventletEvent.wait`, so that it matches the
+  :class:`~threading.Event` API.
+  (PR: :issue:`91`)
+
 
 v2.0.2 (2019-12-02)
 ===================

--- a/pykka/eventlet.py
+++ b/pykka/eventlet.py
@@ -28,7 +28,7 @@ class EventletEvent(eventlet.event.Event):
         if self.ready():
             self.reset()
 
-    def wait(self, timeout):
+    def wait(self, timeout=None):
         if timeout is not None:
             wait_timeout = eventlet.Timeout(timeout)
 

--- a/pykka/eventlet.py
+++ b/pykka/eventlet.py
@@ -24,8 +24,6 @@ class EventletEvent(eventlet.event.Event):
     def is_set(self):
         return self.ready()
 
-    isSet = is_set
-
     def clear(self):
         if self.ready():
             self.reset()


### PR DESCRIPTION
This fixes inconsistencies between the `pykka.eventlet.EventletEvent` API and Python 3's `threading.Event` API.