### PR TITLE
Akka-style message Scheduler

### DIFF
--- a/pykka/__init__.py
+++ b/pykka/__init__.py
@@ -9,6 +9,7 @@ from pykka._ref import ActorRef
 from pykka._registry import ActorRegistry
 from pykka._actor import Actor  # noqa: Must be imported late
 from pykka._threading import ThreadingActor, ThreadingFuture
+from pykka._scheduler import Scheduler, Cancellable
 
 
 __all__ = [
@@ -18,7 +19,9 @@ __all__ = [
     "ActorRef",
     "ActorRegistry",
     "CallableProxy",
+    "Cancellable",
     "Future",
+    "Scheduler",
     "ThreadingActor",
     "ThreadingFuture",
     "Timeout",

--- a/pykka/_scheduler.py
+++ b/pykka/_scheduler.py
@@ -1,0 +1,262 @@
+import logging
+import time
+from threading import Timer, Lock
+from typing import Any, Optional
+
+from pykka import ActorRef
+
+logger = logging.getLogger("pykka")
+
+__all__ = ["Scheduler", "Cancellable"]
+
+
+class Cancellable:
+    """
+    Signifies a delayed task that can be cancelled.
+
+    Built around a `threading.Timer` object and is able to cancel it.
+    For periodical jobs its `_timer` property is being updated on
+    every run from a separated thread, so to avoid race conditions where
+    in the middle of the `cancel` run another thread updates the `_timer`
+    property with a non-cancelled timer, Lock is used.
+    """
+
+    def __init__(self, timer):
+        self._cancelled = False
+        self._timer = timer
+        self._timer_lock = Lock()
+
+    def is_cancelled(self) -> bool:
+        """
+        `._cancelled` property getter for external users.
+
+        There is no external setter for this property.
+
+        Returns: Bool that shows whether it is cancelled.
+        """
+        return self._cancelled
+
+    def set_timer(self, timer: Timer) -> bool:
+        """
+        `_.timer` property setter to update timers for periodic jobs.
+
+        There is no external getter for this property.
+
+        Cancelled Canellable objects shouldn't allow to update their timers.
+
+        Args:
+            timer (Timer): Timer object handling a delayed task execution.
+        Returns: Bool that shows whether the '_.timer` property was updated.
+        """
+        with self._timer_lock:
+            if self.is_cancelled():
+                logger.error(
+                    "An attempt to update a timer for a stopped Cancellable happened."
+                )
+                return False
+            else:
+                self._timer = timer
+                return True
+
+    def cancel(self) -> bool:
+        """
+        Cancels the Cancellable by stopping its timer.
+
+        Returns True only if it is not in a cancelled state.
+        If it was requested to cancel an already cancelled Cancellable,
+        it returns False to be consistent with a Cancellable object
+        from Akka.
+
+        Returns: Bool that shows whether this request actually cancelled
+                 the Cancellable timer.
+        """
+        with self._timer_lock:
+            if self.is_cancelled():
+                return False
+            else:
+                if isinstance(self._timer, Timer):
+                    self._timer.cancel()
+                self._cancelled = True
+                return True
+
+
+class Scheduler:
+    """
+    A basic Pykka Scheduler service based on Akka Scheduler behaviour.
+
+    Its main purpose is to tell a message to an actor after a specified
+    delay or to do it periodically. It isn't a long-term scheduler
+    and is expected to be used for retransmitting messages or to schedule
+    periodic startup of an actor-based data processing pipeline.
+    """
+
+    @staticmethod
+    def schedule_once(delay: float, receiver: ActorRef, message: Any) -> Cancellable:
+        """
+        Based on:
+        akka.Scheduler.scheduleOnce(
+            delay: java.time.Duration,
+            receiver: ActorRef,
+            message: Any
+        ): Cancellable
+
+        Creates a ``threading.Timer`` object to ``tell`` a message to an
+        actor once after a specified delay. The returning Cancellable object
+        can be cancelled before a message was sent.
+
+        Args:
+            delay (float): How much time in ``seconds`` must pass before execution.
+            receiver (ActorRef): Actor Reference of an addressee.
+            message (Any): Message to send to an addressee.
+        Returns: A Cancellable object.
+        """
+        timer = Timer(interval=delay, function=receiver.tell, args=(message,))
+        timer.start()
+        return Cancellable(timer)
+
+    @classmethod
+    def schedule_at_fixed_rate(
+        cls, initial_delay: float, interval: float, receiver: ActorRef, message: Any
+    ) -> Cancellable:
+        """
+        Based on:
+        akka.Scheduler.scheduleAtFixedRate(
+            initialDelay: FiniteDuration,
+            interval: FiniteDuration,
+            receiver: ActorRef,
+            message: Any
+        ): Cancellable
+
+        Schedules a message to be sent to an actor PRECISELY every `delay`
+        seconds after waiting for an `initial_delay` amount of seconds.
+        Any time drift is compensated here by performing additional
+        calculations.
+
+        Args:
+            initial_delay (float): How many seconds we wait before the first execution.
+            interval (float): How many seconds we wait between executions.
+            receiver (ActorRef): Actor Reference of an addressee.
+            message (Any): Message to send to an addressee.
+        Returns: A Cancellable object.
+        """
+        return cls._tell_periodically(
+            initial_delay, interval, receiver, message, precise=True
+        )
+
+    @classmethod
+    def schedule_with_fixed_delay(
+        cls, initial_delay: float, delay: float, receiver: ActorRef, message: Any
+    ) -> Cancellable:
+        """
+        Based on:
+        akka.Scheduler.scheduleWithFixedDelay(
+            initialDelay: FiniteDuration,
+            delay: FiniteDuration,
+            receiver: ActorRef,
+            message: Any
+        ): Cancellable
+
+        Schedules a message to be sent to an actor every `delay` seconds after
+        waiting for an `initial_delay` amount of seconds. This is not a precise
+        method, so there can be a slight time drift.
+
+        Args:
+            initial_delay (float): How many seconds we wait before the first execution.
+            delay (float): How many seconds we wait between executions.
+            receiver (ActorRef): Actor Reference of an addressee.
+            message (Any): Message to send to an addressee.
+        Returns: A Cancellable object.
+        """
+        return cls._tell_periodically(
+            initial_delay, delay, receiver, message, precise=False
+        )
+
+    @classmethod
+    def _tell_periodically(
+        cls,
+        initial_delay: float,
+        interval: float,
+        receiver: ActorRef,
+        message: Any,
+        precise: bool,
+    ) -> Cancellable:
+        """
+        A generic method to handle both precise and imprecise versions of
+        periodical message sending.
+
+        It returns a Cancellable object, that can anytime cancel scheduled
+        executions by calling its `.cancel()` method. Its `._timer` property
+        is being updated via a pseudo-callback `_execute_and_update_cancellable`
+        that sends a message and creates a new Timer for another execution.
+        To keep it cancellable, this callback replaces an expired timer of
+        the returned Cancellable object with this newly created timer.
+
+        Args:
+            initial_delay (float): How many seconds we wait before the first execution.
+            interval (float): How many seconds we wait between executions.
+            receiver (ActorRef): Actor Reference of an addressee.
+            message (Any): Message to send to an addressee.
+            precise (bool): Defines whether the time drift should be compensated to keep
+                            the fixed messaging rate.
+        Returns: A Cancellable object.
+        """
+        cancellable = Cancellable(None)
+
+        if precise:
+            started = time.time() + initial_delay
+        else:
+            started = None
+
+        timer = Timer(
+            interval=initial_delay,
+            function=cls._tell_and_update_cancellable,
+            args=(cancellable, interval, receiver, message, started),
+        )
+        timer.start()
+
+        cancellable.set_timer(timer)
+        return cancellable
+
+    @classmethod
+    def _tell_and_update_cancellable(
+        cls,
+        cancellable: Cancellable,
+        interval: float,
+        receiver: ActorRef,
+        message: Any,
+        started: Optional[float] = None,
+    ):
+        """
+        A pseudo-callback function that creates a new Timer for the next
+        message delivery and updates a Cancellable object with this Timer
+        to keep the scheduled activity cancellable.
+
+        If `started` parameter is not None, it tried to be as precise as
+        possible and to calculate and compensate time drift from the 'ideal'
+        execution time.
+
+        Args:
+            cancellable (Cancellable): A previously returned object whose
+                `_timer` property we need to update.
+            interval (float): How many seconds we wait between executions.
+            receiver (ActorRef): Actor Reference of an addressee.
+            message (Any): Message to send to an addressee.
+            started (Optional[float]): Unix timestamp that says when our
+                first execution was happened. If set, it's used to calculate
+                and compensate time drift between executions.
+        Returns: None, since that's a pseudo-callback.
+        """
+        if started:
+            delay = interval - (time.time() - started) % interval
+        else:
+            delay = interval
+
+        timer = Timer(
+            interval=delay,
+            function=cls._tell_and_update_cancellable,
+            args=(cancellable, interval, receiver, message, started),
+        )
+        timer.start()
+
+        receiver.tell(message)
+        cancellable.set_timer(timer)

--- a/pykka/_scheduler.py
+++ b/pykka/_scheduler.py
@@ -22,9 +22,9 @@ class Cancellable:
     """
 
     def __init__(self, timer):
-        self._cancelled = False
-        self._timer = timer
-        self._timer_lock = Lock()
+        self._cancelled: bool = False
+        self._timer: Optional[Timer] = timer
+        self._timer_lock: Lock = Lock()
 
     def is_cancelled(self) -> bool:
         """
@@ -84,7 +84,7 @@ class Scheduler:
     """
     A basic Pykka Scheduler service based on Akka Scheduler behaviour.
 
-    Its main purpose is to tell a message to an actor after a specified
+    Its main purpose is to `tell` a message to an actor after a specified
     delay or to do it periodically. It isn't a long-term scheduler
     and is expected to be used for retransmitting messages or to schedule
     periodic startup of an actor-based data processing pipeline.
@@ -102,7 +102,7 @@ class Scheduler:
             message: Any
         ): Cancellable
 
-        Creates a ``threading.Timer`` object to ``tell`` a message to an
+        Creates a `threading.Timer` object to `tell` a message to an
         actor once after a specified delay. The returning Cancellable object
         can be cancelled before a message was sent.
 

--- a/pykka/_scheduler.py
+++ b/pykka/_scheduler.py
@@ -91,7 +91,9 @@ class Scheduler:
     """
 
     @staticmethod
-    def schedule_once(delay: float, receiver: ActorRef, message: Any) -> Cancellable:
+    def schedule_once(
+            delay: float, receiver: ActorRef, message: Any
+    ) -> Cancellable:
         """
         Based on:
         akka.Scheduler.scheduleOnce(
@@ -116,7 +118,11 @@ class Scheduler:
 
     @classmethod
     def schedule_at_fixed_rate(
-        cls, initial_delay: float, interval: float, receiver: ActorRef, message: Any
+            cls,
+            initial_delay: float,
+            interval: float,
+            receiver: ActorRef,
+            message: Any,
     ) -> Cancellable:
         """
         Based on:
@@ -145,7 +151,11 @@ class Scheduler:
 
     @classmethod
     def schedule_with_fixed_delay(
-        cls, initial_delay: float, delay: float, receiver: ActorRef, message: Any
+            cls,
+            initial_delay: float,
+            delay: float,
+            receiver: ActorRef,
+            message: Any,
     ) -> Cancellable:
         """
         Based on:
@@ -173,12 +183,12 @@ class Scheduler:
 
     @classmethod
     def _tell_periodically(
-        cls,
-        initial_delay: float,
-        interval: float,
-        receiver: ActorRef,
-        message: Any,
-        precise: bool,
+            cls,
+            initial_delay: float,
+            interval: float,
+            receiver: ActorRef,
+            message: Any,
+            precise: bool,
     ) -> Cancellable:
         """
         A generic method to handle both precise and imprecise versions of
@@ -219,12 +229,12 @@ class Scheduler:
 
     @classmethod
     def _tell_and_update_cancellable(
-        cls,
-        cancellable: Cancellable,
-        interval: float,
-        receiver: ActorRef,
-        message: Any,
-        started: Optional[float] = None,
+            cls,
+            cancellable: Cancellable,
+            interval: float,
+            receiver: ActorRef,
+            message: Any,
+            started: Optional[float] = None,
     ):
         """
         A pseudo-callback function that creates a new Timer for the next
@@ -247,7 +257,8 @@ class Scheduler:
         Returns: None, since that's a pseudo-callback.
         """
         if started:
-            delay = interval - (time.time() - started) % interval
+            time_drift = (time.time() - started) % interval
+            delay = interval - time_drift
         else:
             delay = interval
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,154 @@
+import time
+from threading import Timer
+
+import pytest
+
+from pykka import Scheduler, Cancellable
+
+PERIODIC_JOB_METHODS = (
+    Scheduler.schedule_at_fixed_rate,
+    Scheduler.schedule_with_fixed_delay,
+)
+
+
+@pytest.fixture(scope="module", params=PERIODIC_JOB_METHODS)
+def periodic_job_method(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def counting_actor_class(runtime):
+    class CountingActor(runtime.actor_class):
+        def __init__(self):
+            super().__init__()
+            self.count = 0
+
+        def on_receive(self, message):
+            if message.get("command") == "return count":
+                return self.count
+            else:
+                self.count += 1
+
+    return CountingActor
+
+
+@pytest.fixture
+def actor_ref(counting_actor_class):
+    ref = counting_actor_class.start()
+    yield ref
+    ref.stop()
+
+
+@pytest.fixture(params=[None, Timer(1, print, ("Hello Pykka!",))])
+def timer(request):
+    test_timer = request.param
+    yield test_timer
+    if isinstance(test_timer, Timer):
+        test_timer.cancel()
+
+
+def test_cancellable_is_cancellable(timer):
+    cancellable = Cancellable(timer)
+    first_check = cancellable.is_cancelled()
+    result = cancellable.cancel()
+    second_check = cancellable.is_cancelled()
+    assert first_check is False
+    assert result is True
+    assert second_check is True
+
+
+def test_cancelled_cancellable_is_not_cancellable(timer):
+    cancellable = Cancellable(timer)
+    cancellable.cancel()
+    result = cancellable.cancel()
+    assert result is False
+
+
+def test_cancellable_set_timer(timer):
+    cancellable = Cancellable(None)
+    result = cancellable.set_timer(timer)
+    assert cancellable._timer == timer
+    assert result is True
+
+
+def test_cancelled_cancellable_set_timer(timer):
+    cancellable = Cancellable("Not a timer or None")
+    cancellable.cancel()
+    result = cancellable.set_timer(timer)
+    assert cancellable._timer == "Not a timer or None"
+    assert result is False
+
+
+def test_schedule_once_sends_a_message_only_once(actor_ref):
+    Scheduler.schedule_once(0.2, actor_ref, {"command": "increment"})
+    time.sleep(0.3)
+    first_count = actor_ref.ask({"command": "return count"})
+    time.sleep(0.3)
+    second_count = actor_ref.ask({"command": "return count"})
+    assert first_count == 1
+    assert second_count == first_count
+
+
+def test_schedule_once_is_cancellable(actor_ref):
+    cancellable = Scheduler.schedule_once(
+        0.2, actor_ref, {"command": "increment"}
+    )
+    cancellable.cancel()
+    time.sleep(0.3)
+    count = actor_ref.ask({"command": "return count"})
+    assert count == 0
+
+
+def test_periodic_job_is_cancellable_before_the_first_run(
+    periodic_job_method, actor_ref
+):
+    cancellable = periodic_job_method(
+        0.1, 0.1, actor_ref, {"command": "increment"}
+    )
+    cancellable.cancel()
+    time.sleep(0.2)
+    count = actor_ref.ask({"command": "return count"})
+    assert count == 0
+
+
+def test_periodic_job_is_cancellable_after_the_first_run(
+    periodic_job_method, actor_ref
+):
+    cancellable = periodic_job_method(
+        0.1, 0.1, actor_ref, {"command": "increment"}
+    )
+    time.sleep(0.15)
+    cancellable.cancel()
+    first_count = actor_ref.ask({"command": "return count"})
+    time.sleep(0.1)
+    second_count = actor_ref.ask({"command": "return count"})
+    assert first_count == 1
+    assert second_count == first_count
+
+
+def test_periodic_job_is_executed_periodically(periodic_job_method, actor_ref):
+    cancellable = periodic_job_method(
+        0.1, 0.1, actor_ref, {"command": "increment"}
+    )
+    time.sleep(0.15)
+    first_count = actor_ref.ask({"command": "return count"})
+    time.sleep(0.1)
+    second_count = actor_ref.ask({"command": "return count"})
+    time.sleep(0.1)
+    third_count = actor_ref.ask({"command": "return count"})
+    cancellable.cancel()
+    assert first_count == 1
+    assert second_count == 2
+    assert third_count == 3
+
+
+def test_periodic_job_stops_when_actor_is_stopped(
+    periodic_job_method, counting_actor_class
+):
+    actor_ref = counting_actor_class.start()
+    cancellable = periodic_job_method(
+        0.1, 0.1, actor_ref, {"command": "increment"}
+    )
+    actor_ref.stop()
+    time.sleep(0.15)
+    assert cancellable._timer.is_alive() is False


### PR DESCRIPTION
First of all, thanks for Pykka, it's really nice!
There is this issue about auto-scheduling: https://github.com/jodal/pykka/issues/53

I needed this functionality for my project as well, because I believe, that an ability to use schedulers to retransmit messages, schedule job executions and so on, is quite a bit part of Akka, so I created it for myself and I hope, it could be useful for Pykka community as well.

Basically, I implemented the simplest versions of `Cancellable`, `Scheduler.scheduleOnce`, `Scheduler.scheduleWithFixedDelay` and `Scheduler.scheduleAtFixedRate` from Akka.

However, working on tests, I found out that it doesn't work with `eventlet`.
It looks for me like an `eventlet` (I use version `0.25.2`) issue with `threading.Timer`.

If this:
```python
import eventlet
from threading import Timer
eventlet.monkey_patch()

timer = Timer(1, print, ("Hello, eventlet!",))
timer.start()
timer = Timer(1, print, ("Hello, eventlet!",))
timer.start()
```
or this code is executed in REPL:
```python
from eventlet.green.threading import Timer
timer = Timer(1, print, ("Hello, eventlet!",))
timer.start()
timer = Timer(1, print, ("Hello, eventlet!",))
timer.start()
```
on the first `t.start()` nothing is being printed. On the second `t.start()` (and all the following attempts) it prints "_Hello, eventlet!_" the same moment as it's called without any timeout.
Same happens with the schedulers if `eventlet` is used, so it basically doesn't work. 

However, both `threading` (that's what I use) and `gevent` (according to tests) actors seem to work fine. So I hope, this addition can be useful for those who don't use `eventlet`. 
Meanwhile I'll create an issue for this `Timer` behaviour in `eventlet` project.

Cheers!