### PR TITLE
Akka style `Become` and `Unbecome`

### DIFF
--- a/pykka/_actor.py
+++ b/pykka/_actor.py
@@ -127,7 +127,8 @@ class Actor:
     #: continue processing messages. Use :meth:`stop` to change it.
     actor_stopped = None
 
-    #: A stack of message handlers. These handlers are
+    #: A stack of message handlers. These handlers are tuples of a function and
+    #: its args. It always has at least one element - default :meth:`on_receive`.
     actor_message_handlers = None
 
     def __init__(self, *args, **kwargs):

--- a/pykka/_actor.pyi
+++ b/pykka/_actor.pyi
@@ -1,6 +1,7 @@
 import threading
+from collections import deque
 from types import TracebackType
-from typing import Any, Dict, Sequence, Type
+from typing import Any, Callable, Dict, Sequence, Type
 
 from typing_extensions import Protocol  # Py38+: Available in ``typing``
 
@@ -23,6 +24,7 @@ class Actor:
     actor_inbox: ActorInbox
     actor_ref: ActorRef
     actor_stopped: threading.Event
+    actor_message_handlers: deque
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     def __str__(self) -> str: ...
     def stop(self) -> None: ...
@@ -30,6 +32,10 @@ class Actor:
     def _actor_loop(self) -> None: ...
     def on_start(self) -> None: ...
     def on_stop(self) -> None: ...
+    def _unbecome(self) -> None: ...
+    def _become(
+        self, func: Callable, *args: Any, discard_old: bool
+    ) -> None: ...
     def _handle_failure(
         self,
         exception_type: Type[BaseException],

--- a/pykka/_ref.pyi
+++ b/pykka/_ref.pyi
@@ -1,11 +1,5 @@
 import threading
-from typing import (
-    Any,
-    Optional,
-    Type,
-    Union,
-    overload,
-)
+from typing import Any, Optional, Type, Union, overload
 
 from typing_extensions import Literal
 
@@ -32,10 +26,7 @@ class ActorRef:
     ) -> Future[Any]: ...
     @overload  # noqa: Allow redefinition
     def ask(
-        self,
-        message: Any,
-        block: Literal[True],
-        timeout: Optional[float] = ...,
+        self, message: Any, block: Literal[True], timeout: Optional[float] = ...
     ) -> Any: ...
     @overload  # noqa: Allow redefinition
     def ask(

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,9 +1,4 @@
-from pykka.messages import (
-    ProxyCall,
-    ProxyGetAttr,
-    ProxySetAttr,
-    _ActorStop,
-)
+from pykka.messages import ProxyCall, ProxyGetAttr, ProxySetAttr, _ActorStop
 
 
 def test_actor_stop():


### PR DESCRIPTION
Based on this issue: https://github.com/jodal/pykka/issues/38

This PR adds two methods to the standard `Actor` class:
1. Method `_become(self, func, *args, discard_old=True)` changes message handing behaviour to a specified function.
* `func`parameter is a callable function that should be executed on message receive.
* `*args` parameter allows us to pass any values we need to the function and to avoid using "mutable" class-level variables to keep actor state.
* `discard_old=True` parameter says whether it should to replace actual behaviour with this new handler completely or it should stash handlers in a handlers stack to be able to return back to them.
2. Method `_unbecome(self)` changes actor's message processing strategy to the previous one.
* If `_become` was used with `discard_old=True` option, `_unbecome` switches behaviour to the standard `on_receive` method.
* If `_become` was used with `discard_old=False` option and there are `n` message handlers in stack, behaviour will change to the handler `n-1`.
* If `_become` wasn't used, and actual behaviour is the default one, nothing happens.