### PR TITLE
Delayed messages

### DIFF
--- a/src/pykka/_envelope.py
+++ b/src/pykka/_envelope.py
@@ -1,3 +1,6 @@
+import time
+
+
 class Envelope:
     """
     Envelope to add metadata to a message.
@@ -11,11 +14,16 @@ class Envelope:
     """
 
     # Using slots speeds up envelope creation with ~20%
-    __slots__ = ["message", "reply_to"]
+    __slots__ = ["message", "reply_to", "timestamp"]
 
-    def __init__(self, message, reply_to=None):
+    def __init__(self, message, reply_to=None, delay=0):
         self.message = message
         self.reply_to = reply_to
+        self.timestamp = time.monotonic() + delay
 
     def __repr__(self):
-        return f"Envelope(message={self.message!r}, reply_to={self.reply_to!r})"
+        return (
+            f"Envelope(message={self.message!r}, "
+            f"reply_to={self.reply_to!r}, "
+            f"timestamp={self.timestamp})"
+        )

--- a/src/pykka/_envelope.pyi
+++ b/src/pykka/_envelope.pyi
@@ -1,9 +1,15 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from pykka import Future
 
 class Envelope:
     message: Any
     reply_to: Optional[Future]
-    def __init__(self, message: Any, reply_to: Optional[Future] = ...) -> None: ...
+    timestamp: float
+    def __init__(
+        self,
+        message: Any,
+        reply_to: Optional[Future] = ...,
+        delay: Union[float, int] = ...,
+    ) -> None: ...
     def __repr__(self) -> str: ...

--- a/src/pykka/_ref.py
+++ b/src/pykka/_ref.py
@@ -1,5 +1,5 @@
-from pykka import ActorDeadError, ActorProxy
 from pykka._envelope import Envelope
+from pykka._proxy import ActorDeadError, ActorProxy, ExtendedActorProxy
 from pykka.messages import _ActorStop
 
 __all__ = ["ActorRef"]
@@ -107,9 +107,7 @@ class ActorRef:
         except ActorDeadError:
             future.set_exception()
         else:
-            self.actor_inbox.put(
-                Envelope(message, reply_to=future, delay=delay)
-            )
+            self.actor_inbox.put(Envelope(message, reply_to=future, delay=delay))
 
         if block:
             return future.get(timeout=timeout)
@@ -153,7 +151,7 @@ class ActorRef:
         else:
             return converted_future
 
-    def proxy(self):
+    def proxy(self, extended=False):
         """
         Wraps the :class:`ActorRef` in an :class:`ActorProxy
         <pykka.ActorProxy>`.
@@ -169,4 +167,7 @@ class ActorRef:
         :raise: :exc:`pykka.ActorDeadError` if actor is not available
         :return: :class:`pykka.ActorProxy`
         """
-        return ActorProxy(self)
+        if extended:
+            return ExtendedActorProxy(self)
+        else:
+            return ActorProxy.from_actor_ref(self)

--- a/src/pykka/_ref.py
+++ b/src/pykka/_ref.py
@@ -55,7 +55,7 @@ class ActorRef:
         """
         return not self.actor_stopped.is_set()
 
-    def tell(self, message):
+    def tell(self, message, delay=0):
         """
         Send message to actor without waiting for any response.
 
@@ -70,9 +70,9 @@ class ActorRef:
         """
         if not self.is_alive():
             raise ActorDeadError(f"{self} not found")
-        self.actor_inbox.put(Envelope(message))
+        self.actor_inbox.put(Envelope(message, delay=delay))
 
-    def ask(self, message, block=True, timeout=None):
+    def ask(self, message, block=True, timeout=None, delay=0):
         """
         Send message to actor and wait for the reply.
 
@@ -107,7 +107,9 @@ class ActorRef:
         except ActorDeadError:
             future.set_exception()
         else:
-            self.actor_inbox.put(Envelope(message, reply_to=future))
+            self.actor_inbox.put(
+                Envelope(message, reply_to=future, delay=delay)
+            )
 
         if block:
             return future.get(timeout=timeout)

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -95,6 +95,10 @@ class ThreadingActor(Actor):
         return queue.Queue()
 
     @staticmethod
+    def _queue_empty_exception():
+        return queue.Empty
+
+    @staticmethod
     def _create_future():
         return ThreadingFuture()
 

--- a/tests/proxy/test_proxy.py
+++ b/tests/proxy/test_proxy.py
@@ -26,7 +26,7 @@ def actor_class(runtime):
 
 @pytest.fixture
 def proxy(actor_class):
-    proxy = ActorProxy(actor_class.start())
+    proxy = ActorProxy.from_actor_ref(actor_class.start())
     yield proxy
     proxy.stop()
 
@@ -110,7 +110,7 @@ def test_proxy_constructor_raises_exception_if_actor_is_dead(actor_class):
     actor_ref.stop()
 
     with pytest.raises(ActorDeadError) as exc_info:
-        ActorProxy(actor_ref)
+        ActorProxy.from_actor_ref(actor_ref)
 
     assert str(exc_info.value) == f"{actor_ref} not found"
 

--- a/tests/proxy/test_static_method_calls.py
+++ b/tests/proxy/test_static_method_calls.py
@@ -89,7 +89,7 @@ def test_call_to_unknown_method_raises_attribute_error(proxy):
 
     result = str(exc_info.value)
 
-    assert result.startswith("<ActorProxy for ActorA")
+    assert result.startswith("<ActorProxyMessageBuilder for ActorA")
     assert result.endswith("has no attribute 'unknown_method'")
 
 
@@ -99,7 +99,7 @@ def test_deferred_call_to_unknown_method_raises_attribute_error(proxy):
 
     result = str(exc_info.value)
 
-    assert result.startswith("<ActorProxy for ActorA")
+    assert result.startswith("<ActorProxyMessageBuilder for ActorA")
     assert result.endswith("has no attribute 'unknown_method'")
 
 

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,7 +1,18 @@
+import re
+import time
+
 from pykka._envelope import Envelope
 
 
 def test_envelope_repr():
-    envelope = Envelope("message", reply_to=123)
+    current_time = time.monotonic()
+    delay = 10
+    envelope = Envelope("message", reply_to=123, delay=delay)
+    match = re.match(
+        r"Envelope\(message='message', reply_to=123, timestamp=([\d\.]+)\)",
+        repr(envelope),
+    )
 
-    assert repr(envelope) == "Envelope(message='message', reply_to=123)"
+    assert match is not None
+    # there will be some difference, execution takes time
+    assert abs(float(match.group(1)) - current_time - delay) < 0.1


### PR DESCRIPTION
This PR implements delayed message delivery, useful for creating event loops which can still be terminated at a moment's notice. Possibly fixes #44. Also fixes an unrelated bug in `eventlet.Event` that caused `event.wait()` to result in an `AttributeError`.

Supporting delay in `ask`/`tell` is pretty straightforward, but doing it for `proxy()` requires some additional indirection. It is in the commit by itself now, because I understand that the approach I used may be questionable; I also hasn't changed the docs/tests because there is a probability the interface will be changed. Currently one would use delayed proxies as
```
proxy = actor_ref.proxy(extended=True)
proxy.delayed(1).something()
proxy.delayed(2).some.attr = 1
```
All the introspection is only done once when `proxy_base` is created.

This PR has some intersection of functionality with PR #95, but is simpler and gives actors more control of the process (specifically, it is more convenient for event loop organization).


