### PR TITLE
Improve types through typing all tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,17 +48,13 @@ pytest-mock = "^3.10.0"
 target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.mypy]
+disallow_untyped_defs = true
 no_implicit_optional = true
 strict_equality = true
 warn_return_any = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unused_configs = true
-
-[[tool.mypy.overrides]]
-# Options that only applies to src, and not tests
-module = "pykka.*"
-disallow_untyped_defs = true
 
 [tool.ruff]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ toml = "^0.10.2"
 mypy = "^1.3.0"
 
 [tool.poetry.group.pyright.dependencies]
-pyright = "^1.1.311"
+pyright = "^1.1.313"
 
 [tool.poetry.group.ruff.dependencies]
 ruff = "^0.0.270"

--- a/src/pykka/_actor.py
+++ b/src/pykka/_actor.py
@@ -154,8 +154,13 @@ class Actor:
     #: friends to put messages in the inbox.
     actor_inbox: ActorInbox
 
-    #: The actor's :class:`ActorRef` instance.
-    actor_ref: ActorRef[Any]
+    _actor_ref: ActorRef[Any]
+
+    @property
+    def actor_ref(self: A) -> ActorRef[A]:
+        """The actor's :class:`ActorRef` instance."""
+        # This property only exists to improve the typing of the ActorRef.
+        return self._actor_ref
 
     #: A :class:`threading.Event` representing whether or not the actor should
     #: continue processing messages. Use :meth:`stop` to change it.
@@ -187,7 +192,7 @@ class Actor:
         self.actor_inbox = self._create_actor_inbox()
         self.actor_stopped = threading.Event()
 
-        self.actor_ref = ActorRef(self)
+        self._actor_ref = ActorRef(self)
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__} ({self.actor_urn})"

--- a/src/pykka/_actor.py
+++ b/src/pykka/_actor.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import threading
 import uuid
-from typing import TYPE_CHECKING, Any, Optional, Protocol, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Sequence, TypeVar
 
 from pykka import ActorDeadError, ActorRef, ActorRegistry, messages
 
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
 __all__ = ["Actor"]
 
 logger = logging.getLogger("pykka")
+
+
+A = TypeVar("A", bound="Actor")
 
 
 class ActorInbox(Protocol):
@@ -75,10 +78,10 @@ class Actor:
 
     @classmethod
     def start(
-        cls,
+        cls: type[A],
         *args: Any,
         **kwargs: Any,
-    ) -> ActorRef:
+    ) -> ActorRef[A]:
         """Start an actor.
 
         Starting an actor also registers it in the
@@ -152,7 +155,7 @@ class Actor:
     actor_inbox: ActorInbox
 
     #: The actor's :class:`ActorRef` instance.
-    actor_ref: ActorRef
+    actor_ref: ActorRef[Any]
 
     #: A :class:`threading.Event` representing whether or not the actor should
     #: continue processing messages. Use :meth:`stop` to change it.

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -46,6 +46,9 @@ class Future(Generic[T]):
         self._get_hook = None
         self._get_hook_result = None
 
+    def __repr__(self) -> str:
+        return "<pykka.Future>"
+
     def get(
         self,
         timeout: Optional[float] = None,

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -23,9 +23,8 @@ __all__ = ["Future", "get_all"]
 
 T = TypeVar("T")
 J = TypeVar("J")  # For when T is Iterable[J]
-
-M = TypeVar("M")  # For Future.map()
-R = TypeVar("R")  # For Future.reduce()
+M = TypeVar("M")  # Result of Future.map()
+R = TypeVar("R")  # Result of Future.reduce()
 
 GetHookFunc: TypeAlias = Callable[[Optional[float]], T]
 

--- a/src/pykka/_proxy.py
+++ b/src/pykka/_proxy.py
@@ -23,7 +23,7 @@ __all__ = ["ActorProxy"]
 logger = logging.getLogger("pykka")
 
 
-_T = TypeVar("_T")
+T = TypeVar("T")
 
 AttrPath: TypeAlias = Sequence[str]
 
@@ -362,7 +362,7 @@ class CallableProxy:
         self.actor_ref.tell(message)
 
 
-def traversable(obj: _T) -> _T:
+def traversable(obj: T) -> T:
     """Mark an actor attribute as traversable.
 
     The traversable marker makes the actor attribute's own methods and

--- a/src/pykka/_proxy.py
+++ b/src/pykka/_proxy.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Sequence,
     TypeVar,
-    Union,
 )
 
 from pykka import ActorDeadError, messages
@@ -253,10 +252,7 @@ class ActorProxy(Generic[A]):
         result += [attr_path[0] for attr_path in list(self._known_attrs.keys())]
         return sorted(result)
 
-    def __getattr__(
-        self,
-        name: str,
-    ) -> Union[CallableProxy[A], ActorProxy[A], Future[Any]]:
+    def __getattr__(self, name: str) -> Any:
         """Get a field or callable from the actor."""
         attr_path: AttrPath = (*self._attr_path, name)
 

--- a/src/pykka/_ref.py
+++ b/src/pykka/_ref.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from pykka import ActorDeadError, ActorProxy
 from pykka._envelope import Envelope
@@ -9,13 +18,16 @@ from pykka.messages import _ActorStop
 if TYPE_CHECKING:
     from threading import Event
 
-    from pykka import Future
-    from pykka._actor import Actor, ActorInbox
+    from pykka import Actor, Future
+    from pykka._actor import ActorInbox
 
 __all__ = ["ActorRef"]
 
 
-class ActorRef:
+A = TypeVar("A", bound="Actor")
+
+
+class ActorRef(Generic[A]):
     """Reference to a running actor which may safely be passed around.
 
     :class:`ActorRef` instances are returned by :meth:`Actor.start` and the
@@ -27,7 +39,7 @@ class ActorRef:
     """
 
     #: The class of the referenced actor.
-    actor_class: type[Actor]
+    actor_class: type[A]
 
     #: See :attr:`Actor.actor_urn`.
     actor_urn: str
@@ -39,8 +51,8 @@ class ActorRef:
     actor_stopped: Event
 
     def __init__(
-        self,
-        actor: Actor,
+        self: ActorRef[A],
+        actor: A,
     ) -> None:
         self._actor = actor
         self.actor_class = actor.__class__
@@ -223,7 +235,7 @@ class ActorRef:
 
         return converted_future
 
-    def proxy(self) -> ActorProxy:
+    def proxy(self: ActorRef[A]) -> ActorProxy[A]:
         """Wrap the :class:`ActorRef` in an :class:`ActorProxy <pykka.ActorProxy>`.
 
         Using this method like this::

--- a/src/pykka/_registry.py
+++ b/src/pykka/_registry.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+    overload,
+)
 
 if TYPE_CHECKING:
     from pykka import Actor, ActorRef, Future
 
+__all__ = ["ActorRegistry"]
+
 logger = logging.getLogger("pykka")
 
-
-__all__ = ["ActorRegistry"]
+A = TypeVar("A", bound="Actor")
 
 
 class ActorRegistry:
@@ -19,7 +29,7 @@ class ActorRegistry:
     Contains global state, but should be thread-safe.
     """
 
-    _actor_refs: ClassVar[list[ActorRef]] = []
+    _actor_refs: ClassVar[list[ActorRef[Any]]] = []
     _actor_refs_lock: ClassVar[threading.RLock] = threading.RLock()
 
     @classmethod
@@ -49,7 +59,7 @@ class ActorRegistry:
             ref.tell(message)
 
     @classmethod
-    def get_all(cls) -> list[ActorRef]:
+    def get_all(cls) -> list[ActorRef[Any]]:
         """Get all running actors.
 
         :returns: list of :class:`pykka.ActorRef`
@@ -60,8 +70,8 @@ class ActorRegistry:
     @classmethod
     def get_by_class(
         cls,
-        actor_class: type[Actor],
-    ) -> list[ActorRef]:
+        actor_class: type[A],
+    ) -> list[ActorRef[A]]:
         """Get all running actors of the given class or a subclass.
 
         :param actor_class: actor class, or any superclass of the actor
@@ -80,7 +90,7 @@ class ActorRegistry:
     def get_by_class_name(
         cls,
         actor_class_name: str,
-    ) -> list[ActorRef]:
+    ) -> list[ActorRef[Any]]:
         """Get all running actors of the given class name.
 
         :param actor_class_name: actor class name
@@ -99,7 +109,7 @@ class ActorRegistry:
     def get_by_urn(
         cls,
         actor_urn: str,
-    ) -> Optional[ActorRef]:
+    ) -> Optional[ActorRef[Any]]:
         """Get an actor by its universally unique URN.
 
         :param actor_urn: actor URN
@@ -116,7 +126,7 @@ class ActorRegistry:
     @classmethod
     def register(
         cls,
-        actor_ref: ActorRef,
+        actor_ref: ActorRef[Any],
     ) -> None:
         """Register an :class:`ActorRef` in the registry.
 
@@ -188,7 +198,7 @@ class ActorRegistry:
     @classmethod
     def unregister(
         cls,
-        actor_ref: ActorRef,
+        actor_ref: ActorRef[A],
     ) -> None:
         """Remove an :class:`ActorRef <pykka.ActorRef>` from the registry.
 

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -20,10 +20,10 @@ class ThreadingFutureResult(NamedTuple):
     exc_info: Optional[OptExcInfo] = None
 
 
-F = TypeVar("F")
+T = TypeVar("T")
 
 
-class ThreadingFuture(Future[F]):
+class ThreadingFuture(Future[T]):
     """Implementation of :class:`Future` for use with regular Python threads`.
 
     The future is implemented using a :class:`queue.Queue`.

--- a/tests/performance.py
+++ b/tests/performance.py
@@ -1,11 +1,14 @@
 # ruff: noqa: T201
 
+from __future__ import annotations
+
 import time
+from typing import Any, Callable
 
 from pykka import ActorRegistry, ThreadingActor
 
 
-def time_it(func):
+def time_it(func: Callable[[], Any]) -> None:
     start = time.time()
     func()
     elapsed = time.time() - start
@@ -16,7 +19,7 @@ class SomeObject:
     pykka_traversable = False
     cat = "bar.cat"
 
-    def func(self):
+    def func(self) -> None:
         pass
 
 
@@ -26,33 +29,33 @@ class AnActor(ThreadingActor):
 
     foo = "foo"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.cat = "quox"
 
-    def func(self):
+    def func(self) -> None:
         pass
 
 
-def test_direct_plain_attribute_access():
+def test_direct_plain_attribute_access() -> None:
     actor = AnActor.start().proxy()
     for _ in range(10000):
         actor.foo.get()
 
 
-def test_direct_callable_attribute_access():
+def test_direct_callable_attribute_access() -> None:
     actor = AnActor.start().proxy()
     for _ in range(10000):
         actor.func().get()
 
 
-def test_traversable_plain_attribute_access():
+def test_traversable_plain_attribute_access() -> None:
     actor = AnActor.start().proxy()
     for _ in range(10000):
         actor.bar.cat.get()
 
 
-def test_traversable_callable_attribute_access():
+def test_traversable_callable_attribute_access() -> None:
     actor = AnActor.start().proxy()
     for _ in range(10000):
         actor.bar.func().get()

--- a/tests/proxy/test_attribute_access.py
+++ b/tests/proxy/test_attribute_access.py
@@ -1,82 +1,112 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator, NoReturn
+
 import pytest
 
+from pykka import Actor
+
+if TYPE_CHECKING:
+    from pykka import ActorProxy
+    from tests.types import Runtime
+
+
+class PropertyActor(Actor):
+    an_attr = "an_attr"
+    _private_attr = "secret"
+
+    @property
+    def a_ro_property(self) -> str:
+        return "a_ro_property"
+
+    _a_rw_property = "a_rw_property"
+
+    @property
+    def a_rw_property(self) -> str:
+        return self._a_rw_property
+
+    @a_rw_property.setter
+    def a_rw_property(self, value: str) -> None:
+        self._a_rw_property = value
+
 
 @pytest.fixture()
-def actor_class(runtime):
-    class ActorWithProperties(runtime.actor_class):
-        an_attr = "an_attr"
-        _private_attr = "secret"
+def actor_class(runtime: Runtime) -> type[PropertyActor]:
+    class PropertyActorImpl(PropertyActor, runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        pass
 
-        @property
-        def a_ro_property(self):
-            return "a_ro_property"
-
-        _a_rw_property = "a_rw_property"
-
-        @property
-        def a_rw_property(self):
-            return self._a_rw_property
-
-        @a_rw_property.setter
-        def a_rw_property(self, value):
-            self._a_rw_property = value
-
-    return ActorWithProperties
+    return PropertyActorImpl
 
 
 @pytest.fixture()
-def proxy(actor_class):
+def proxy(
+    actor_class: type[PropertyActor],
+) -> Iterator[ActorProxy[PropertyActor]]:
     proxy = actor_class.start().proxy()
     yield proxy
     proxy.stop()
 
 
-def test_attr_can_be_read_using_get_postfix(proxy):
+def test_attr_can_be_read_using_get_postfix(
+    proxy: ActorProxy[PropertyActor],
+) -> None:
     assert proxy.an_attr.get() == "an_attr"
 
 
-def test_attr_can_be_set_using_assignment(proxy):
+def test_attr_can_be_set_using_assignment(
+    proxy: ActorProxy[PropertyActor],
+) -> None:
     assert proxy.an_attr.get() == "an_attr"
 
     proxy.an_attr = "an_attr_2"
 
-    assert proxy.an_attr.get() == "an_attr_2"
+    assert proxy.an_attr.get() == "an_attr_2"  # type: ignore[attr-defined]
 
 
-def test_private_attr_access_raises_exception(proxy):
+def test_private_attr_access_raises_exception(
+    proxy: ActorProxy[PropertyActor],
+) -> None:
     with pytest.raises(AttributeError) as exc_info:
-        proxy._private_attr.get()  # noqa: SLF001
+        proxy._private_attr.get()  # pyright: ignore[reportUnknownMemberType]  # noqa: E501, SLF001
 
     assert "has no attribute '_private_attr'" in str(exc_info.value)
 
 
-def test_missing_attr_access_raises_exception(proxy):
+def test_missing_attr_access_raises_exception(
+    proxy: ActorProxy[PropertyActor],
+) -> None:
     with pytest.raises(AttributeError) as exc_info:
         proxy.missing_attr.get()
 
     assert "has no attribute 'missing_attr'" in str(exc_info.value)
 
 
-def test_property_can_be_read_using_get_postfix(proxy):
+def test_property_can_be_read_using_get_postfix(
+    proxy: ActorProxy[PropertyActor],
+) -> None:
     assert proxy.a_ro_property.get() == "a_ro_property"
     assert proxy.a_rw_property.get() == "a_rw_property"
 
 
-def test_property_can_be_set_using_assignment(proxy):
+def test_property_can_be_set_using_assignment(
+    proxy: ActorProxy[PropertyActor],
+) -> None:
     proxy.a_rw_property = "a_rw_property_2"
 
-    assert proxy.a_rw_property.get() == "a_rw_property_2"
+    assert proxy.a_rw_property.get() == "a_rw_property_2"  # type: ignore[attr-defined]
 
 
-def test_read_only_property_cannot_be_set(proxy):
+def test_read_only_property_cannot_be_set(
+    proxy: ActorProxy[PropertyActor],
+) -> None:
     with pytest.raises(AttributeError):
         proxy.a_ro_property = "a_ro_property_2"
 
 
-def test_property_is_not_accessed_when_creating_proxy(runtime):
-    class ExpensiveSideEffectActor(runtime.actor_class):
+def test_property_is_not_accessed_when_creating_proxy(runtime: Runtime) -> None:
+    class ExpensiveSideEffectActor(runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
         @property
-        def a_property(self):
+        def a_property(self) -> NoReturn:
             # Imagine code with side effects or heavy resource usage here
             raise Exception("Proxy creation accessed property")
 

--- a/tests/proxy/test_dynamic_method_calls.py
+++ b/tests/proxy/test_dynamic_method_calls.py
@@ -1,26 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+
 import pytest
+
+from pykka import Actor
+
+if TYPE_CHECKING:
+    from pykka import ActorProxy, Future
+    from tests.types import Runtime
+
+
+class DynamicMethodActor(Actor):
+    def add_method(self, name: str) -> None:
+        setattr(self, name, lambda: "returned by " + name)
+
+    def use_foo_through_self_proxy(self) -> Future[str]:
+        return self.actor_ref.proxy().foo()  # type: ignore[no-any-return]
 
 
 @pytest.fixture(scope="module")
-def actor_class(runtime):
-    class ActorA(runtime.actor_class):
-        def add_method(self, name):
-            setattr(self, name, lambda: "returned by " + name)
+def actor_class(runtime: Runtime) -> type[DynamicMethodActor]:
+    class DynamicMethodActorImpl(DynamicMethodActor, runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        pass
 
-        def use_foo_through_self_proxy(self):
-            return self.actor_ref.proxy().foo()
-
-    return ActorA
+    return DynamicMethodActorImpl
 
 
 @pytest.fixture()
-def proxy(actor_class):
+def proxy(
+    actor_class: type[DynamicMethodActor],
+) -> Iterator[ActorProxy[DynamicMethodActor]]:
     proxy = actor_class.start().proxy()
     yield proxy
     proxy.stop()
 
 
-def test_can_call_method_that_was_added_at_runtime(proxy):
+def test_can_call_method_that_was_added_at_runtime(
+    proxy: ActorProxy[DynamicMethodActor],
+) -> None:
     # We need to .get() after .add_method() to be sure that the method has
     # been added before we try to use it through the proxy.
     proxy.add_method("foo").get()
@@ -28,7 +46,9 @@ def test_can_call_method_that_was_added_at_runtime(proxy):
     assert proxy.foo().get() == "returned by foo"
 
 
-def test_can_proxy_itself_and_use_attrs_added_at_runtime(proxy):
+def test_can_proxy_itself_and_use_attrs_added_at_runtime(
+    proxy: ActorProxy[DynamicMethodActor],
+) -> None:
     # We don't need to .get() after .add_method() here, because the actor
     # will process the .add_method() call before processing the
     # .use_foo_through_self_proxy() call, which again will use the new

--- a/tests/proxy/test_proxy.py
+++ b/tests/proxy/test_proxy.py
@@ -1,86 +1,106 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+
 import pytest
 
 import pykka
-from pykka import ActorDeadError, ActorProxy
+from pykka import Actor, ActorDeadError, ActorProxy
+from tests.log_handler import LogLevel, PykkaTestLogHandler
+
+if TYPE_CHECKING:
+    from tests.types import Runtime
 
 
 class NestedObject:
     pass
 
 
+class ActorForProxying(Actor):
+    a_nested_object = pykka.traversable(NestedObject())
+    a_class_attr = "class_attr"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.an_instance_attr = "an_instance_attr"
+
+    def a_method(self) -> None:
+        pass
+
+
 @pytest.fixture(scope="module")
-def actor_class(runtime):
-    class ActorForProxying(runtime.actor_class):
-        a_nested_object = pykka.traversable(NestedObject())
-        a_class_attr = "class_attr"
+def actor_class(runtime: Runtime) -> type[ActorForProxying]:
+    class ActorForProxyingImpl(ActorForProxying, runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        pass
 
-        def __init__(self):
-            super(runtime.actor_class, self).__init__()
-            self.an_instance_attr = "an_instance_attr"
-
-        def a_method(self):
-            pass
-
-    return ActorForProxying
+    return ActorForProxyingImpl
 
 
 @pytest.fixture()
-def proxy(actor_class):
+def proxy(
+    actor_class: type[ActorForProxying],
+) -> Iterator[ActorProxy[ActorForProxying]]:
     proxy = ActorProxy(actor_class.start())
     yield proxy
     proxy.stop()
 
 
-def test_eq_to_self(proxy):
+def test_eq_to_self(proxy: ActorProxy[ActorForProxying]) -> None:
     assert proxy == proxy
 
 
-def test_is_hashable(proxy):
+def test_is_hashable(proxy: ActorProxy[ActorForProxying]) -> None:
     assert hash(proxy) == hash(proxy)
 
 
-def test_eq_to_another_proxy_for_same_actor_and_attr_path(proxy):
+def test_eq_to_another_proxy_for_same_actor_and_attr_path(
+    proxy: ActorProxy[ActorForProxying],
+) -> None:
     proxy2 = proxy.actor_ref.proxy()
 
     assert proxy == proxy2
 
 
-def test_not_eq_to_proxy_with_different_attr_path(proxy):
+def test_not_eq_to_proxy_with_different_attr_path(
+    proxy: ActorProxy[ActorForProxying],
+) -> None:
     assert proxy != proxy.a_nested_object
 
 
-def test_repr_is_wrapped_in_lt_and_gt(proxy):
+def test_repr_is_wrapped_in_lt_and_gt(proxy: ActorProxy[ActorForProxying]) -> None:
     result = repr(proxy)
 
     assert result.startswith("<")
     assert result.endswith(">")
 
 
-def test_repr_reveals_that_this_is_a_proxy(proxy):
+def test_repr_reveals_that_this_is_a_proxy(proxy: ActorProxy[ActorForProxying]) -> None:
     assert "ActorProxy" in repr(proxy)
 
 
-def test_repr_contains_actor_class_name(proxy):
+def test_repr_contains_actor_class_name(proxy: ActorProxy[ActorForProxying]) -> None:
     assert "ActorForProxying" in repr(proxy)
 
 
-def test_repr_contains_actor_urn(proxy):
+def test_repr_contains_actor_urn(proxy: ActorProxy[ActorForProxying]) -> None:
     assert proxy.actor_ref.actor_urn in repr(proxy)
 
 
-def test_repr_contains_attr_path(proxy):
+def test_repr_contains_attr_path(proxy: ActorProxy[ActorForProxying]) -> None:
     assert "a_nested_object" in repr(proxy.a_nested_object)
 
 
-def test_str_contains_actor_class_name(proxy):
+def test_str_contains_actor_class_name(proxy: ActorProxy[ActorForProxying]) -> None:
     assert "ActorForProxying" in str(proxy)
 
 
-def test_str_contains_actor_urn(proxy):
+def test_str_contains_actor_urn(proxy: ActorProxy[ActorForProxying]) -> None:
     assert proxy.actor_ref.actor_urn in str(proxy)
 
 
-def test_dir_on_proxy_lists_attributes_of_the_actor(proxy):
+def test_dir_on_proxy_lists_attributes_of_the_actor(
+    proxy: ActorProxy[ActorForProxying],
+) -> None:
     result = dir(proxy)
 
     assert "a_class_attr" in result
@@ -88,7 +108,9 @@ def test_dir_on_proxy_lists_attributes_of_the_actor(proxy):
     assert "a_method" in result
 
 
-def test_dir_on_proxy_lists_private_attributes_of_the_proxy(proxy):
+def test_dir_on_proxy_lists_private_attributes_of_the_proxy(
+    proxy: ActorProxy[ActorForProxying],
+) -> None:
     result = dir(proxy)
 
     assert "__class__" in result
@@ -97,7 +119,9 @@ def test_dir_on_proxy_lists_private_attributes_of_the_proxy(proxy):
     assert "__setattr__" in result
 
 
-def test_refs_proxy_method_returns_a_proxy(actor_class):
+def test_refs_proxy_method_returns_a_proxy(
+    actor_class: type[ActorForProxying],
+) -> None:
     proxy_from_ref_proxy = actor_class.start().proxy()
 
     assert isinstance(proxy_from_ref_proxy, ActorProxy)
@@ -105,7 +129,9 @@ def test_refs_proxy_method_returns_a_proxy(actor_class):
     proxy_from_ref_proxy.stop().get()
 
 
-def test_proxy_constructor_raises_exception_if_actor_is_dead(actor_class):
+def test_proxy_constructor_raises_exception_if_actor_is_dead(
+    actor_class: type[Actor],
+) -> None:
     actor_ref = actor_class.start()
     actor_ref.stop()
 
@@ -115,20 +141,25 @@ def test_proxy_constructor_raises_exception_if_actor_is_dead(actor_class):
     assert str(exc_info.value) == f"{actor_ref} not found"
 
 
-def test_actor_ref_may_be_retrieved_from_proxy_if_actor_is_dead(proxy):
+def test_actor_ref_may_be_retrieved_from_proxy_if_actor_is_dead(
+    proxy: ActorProxy[ActorForProxying],
+) -> None:
     proxy.actor_ref.stop()
 
     assert not proxy.actor_ref.is_alive()
 
 
-def test_actor_proxy_does_not_expose_proxy_to_self(runtime, log_handler):
-    class Actor(runtime.actor_class):
-        def __init__(self):
+def test_actor_proxy_does_not_expose_proxy_to_self(
+    runtime: Runtime,
+    log_handler: PykkaTestLogHandler,
+) -> None:
+    class SelfReferencingActor(runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        def __init__(self) -> None:
             super().__init__()
             self.self_proxy = self.actor_ref.proxy()
             self.foo = "bar"
 
-    actor_ref = Actor.start()
+    actor_ref = SelfReferencingActor.start()
     try:
         proxy = actor_ref.proxy()
 
@@ -138,10 +169,10 @@ def test_actor_proxy_does_not_expose_proxy_to_self(runtime, log_handler):
     finally:
         actor_ref.stop()
 
-    log_handler.wait_for_message("warning")
+    log_handler.wait_for_message(LogLevel.WARNING)
     with log_handler.lock:
-        assert len(log_handler.messages["warning"]) == 2
-        log_record = log_handler.messages["warning"][0]
+        assert len(log_handler.messages[LogLevel.WARNING]) == 2
+        log_record = log_handler.messages[LogLevel.WARNING][0]
 
     assert (
         "attribute 'self_proxy' is a proxy to itself. "

--- a/tests/proxy/test_traversable.py
+++ b/tests/proxy/test_traversable.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+
 import pytest
 
 import pykka
+from pykka import Actor
+
+if TYPE_CHECKING:
+    from pykka import ActorProxy
+    from tests.types import Runtime
 
 
 class NestedWithNoMarker:
@@ -10,7 +19,7 @@ class NestedWithNoMarker:
 class NestedWithNoMarkerAndSlots:
     __slots__ = ["inner"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.inner = "nested_with_no_marker_and_slots.inner"
 
 
@@ -27,36 +36,44 @@ class NestedWithAttrMarker:
 class NestedWithAttrMarkerAndSlots:
     __slots__ = ["pykka_traversable", "inner"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Objects using '__slots__' cannot have class attributes.
         self.pykka_traversable = True
         self.inner = "nested_with_attr_marker_and_slots.inner"
 
 
-@pytest.fixture()
-def actor_class(runtime):
-    class ActorWithTraversableObjects(runtime.actor_class):
-        nested_with_no_marker = NestedWithNoMarker()
-        nested_with_function_marker = pykka.traversable(NestedWithNoMarker())
-        nested_with_decorator_marker = NestedWithDecoratorMarker()
-        nested_with_attr_marker = NestedWithAttrMarker()
-        nested_with_attr_marker_and_slots = NestedWithAttrMarkerAndSlots()
+class TraversableObjectsActor(Actor):
+    nested_with_no_marker = NestedWithNoMarker()
+    nested_with_function_marker = pykka.traversable(NestedWithNoMarker())
+    nested_with_decorator_marker = NestedWithDecoratorMarker()
+    nested_with_attr_marker = NestedWithAttrMarker()
+    nested_with_attr_marker_and_slots = NestedWithAttrMarkerAndSlots()
 
-        @property
-        def nested_object_property(self):
-            return NestedWithAttrMarker()
-
-    return ActorWithTraversableObjects
+    @property
+    def nested_object_property(self) -> NestedWithAttrMarker:
+        return NestedWithAttrMarker()
 
 
 @pytest.fixture()
-def proxy(actor_class):
+def actor_class(runtime: Runtime) -> type[Actor]:
+    class TraversableObjectsActorImpl(TraversableObjectsActor, runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        pass
+
+    return TraversableObjectsActorImpl
+
+
+@pytest.fixture()
+def proxy(
+    actor_class: type[TraversableObjectsActor],
+) -> Iterator[ActorProxy[TraversableObjectsActor]]:
     proxy = actor_class.start().proxy()
     yield proxy
     proxy.stop()
 
 
-def test_attr_without_marker_cannot_be_traversed(proxy):
+def test_attr_without_marker_cannot_be_traversed(
+    proxy: ActorProxy[TraversableObjectsActor],
+) -> None:
     with pytest.raises(AttributeError) as exc_info:
         proxy.nested_with_no_marker.inner.get()
 
@@ -75,13 +92,19 @@ def test_attr_without_marker_cannot_be_traversed(proxy):
         ),
     ],
 )
-def test_attr_of_traversable_attr_can_be_read(proxy, attr_name, expected):
+def test_attr_of_traversable_attr_can_be_read(
+    proxy: ActorProxy[TraversableObjectsActor],
+    attr_name: str,
+    expected: str,
+) -> None:
     attr = getattr(proxy, attr_name)
 
     assert attr.inner.get() == expected
 
 
-def test_traversable_object_returned_from_property_is_not_traversed(proxy):
+def test_traversable_object_returned_from_property_is_not_traversed(
+    proxy: ActorProxy[TraversableObjectsActor],
+) -> None:
     # In Pykka < 2, it worked like this:
     # assert proxy.nested_object_property.inner.get() == 'nested.inner'  # noqa: ERA001
 
@@ -89,7 +112,7 @@ def test_traversable_object_returned_from_property_is_not_traversed(proxy):
     assert proxy.nested_object_property.get().inner == "nested_with_attr_marker.inner"
 
 
-def test_traversable_cannot_mark_object_using_slots():
+def test_traversable_cannot_mark_object_using_slots() -> None:
     with pytest.raises(Exception, match="cannot be used to mark") as exc_info:
         pykka.traversable(NestedWithNoMarkerAndSlots())
 

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -1,77 +1,98 @@
+from __future__ import annotations
+
 import uuid
+from typing import TYPE_CHECKING, Any, Iterator
 
 import pytest
 
-from pykka import ActorDeadError, ActorRegistry
+from pykka import Actor, ActorDeadError, ActorRegistry
+
+if TYPE_CHECKING:
+    from pykka import ActorRef
+    from tests.types import Events, Runtime
 
 pytestmark = pytest.mark.usefixtures("_stop_all")
 
 
+class AnActor(Actor):
+    def __init__(self, events: Events) -> None:
+        super().__init__()
+        self.events = events
+
+    def on_start(self) -> None:
+        self.events.on_start_was_called.set()
+        if ActorRegistry.get_by_urn(self.actor_urn) is not None:
+            self.events.actor_registered_before_on_start_was_called.set()
+
+    def on_stop(self) -> None:
+        self.events.on_stop_was_called.set()
+
+    def on_failure(self, *args: Any) -> None:
+        self.events.on_failure_was_called.set()
+
+    def on_receive(self, message: Any) -> None:
+        if message.get("command") == "raise exception":
+            raise Exception("foo")
+
+        if message.get("command") == "raise base exception":
+            raise BaseException
+
+        if message.get("command") == "stop twice":
+            self.stop()
+            self.stop()
+        elif message.get("command") == "message self then stop":
+            self.actor_ref.tell({"command": "greetings"})
+            self.stop()
+        elif message.get("command") == "greetings":
+            self.events.greetings_was_received.set()
+        elif message.get("command") == "callback":
+            message["callback"]()
+        else:
+            super().on_receive(message)
+
+
+class EarlyStoppingActor(Actor):
+    def __init__(self, events: Events) -> None:
+        super().__init__()
+        self.events = events
+
+    def on_start(self) -> None:
+        self.stop()
+
+    def on_stop(self) -> None:
+        self.events.on_stop_was_called.set()
+
+
 @pytest.fixture(scope="module")
-def actor_class(runtime):  # noqa: C901
-    class ActorA(runtime.actor_class):
-        def __init__(self, events):
-            super().__init__()
-            self.events = events
+def actor_class(runtime: Runtime) -> type[AnActor]:
+    class ActorAImpl(AnActor, runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        pass
 
-        def on_start(self):
-            self.events.on_start_was_called.set()
-            if ActorRegistry.get_by_urn(self.actor_urn) is not None:
-                self.events.actor_registered_before_on_start_was_called.set()
-
-        def on_stop(self):
-            self.events.on_stop_was_called.set()
-
-        def on_failure(self, *args):
-            self.events.on_failure_was_called.set()
-
-        def on_receive(self, message):
-            if message.get("command") == "raise exception":
-                raise Exception("foo")
-
-            if message.get("command") == "raise base exception":
-                raise BaseException
-
-            if message.get("command") == "stop twice":
-                self.stop()
-                self.stop()
-            elif message.get("command") == "message self then stop":
-                self.actor_ref.tell({"command": "greetings"})
-                self.stop()
-            elif message.get("command") == "greetings":
-                self.events.greetings_was_received.set()
-            elif message.get("command") == "callback":
-                message["callback"]()
-            else:
-                super().on_receive(message)
-
-    return ActorA
+    return ActorAImpl
 
 
 @pytest.fixture()
-def actor_ref(actor_class, events):
+def actor_ref(
+    actor_class: type[AnActor],
+    events: Events,
+) -> Iterator[ActorRef[AnActor]]:
     ref = actor_class.start(events)
     yield ref
     ref.stop()
 
 
 @pytest.fixture(scope="module")
-def early_stopping_actor_class(runtime):
-    class EarlyStoppingActor(runtime.actor_class):
-        def __init__(self, events):
-            super().__init__()
-            self.events = events
+def early_stopping_actor_class(runtime: Runtime) -> type[EarlyStoppingActor]:
+    class EarlyStoppingActorImpl(EarlyStoppingActor, runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        pass
 
-        def on_start(self):
-            self.stop()
-
-        def on_stop(self):
-            self.events.on_stop_was_called.set()
-
-    return EarlyStoppingActor
+    return EarlyStoppingActorImpl
 
 
-def test_messages_left_in_queue_after_actor_stops_receive_an_error(runtime, actor_ref):
+def test_messages_left_in_queue_after_actor_stops_receive_an_error(
+    runtime: Runtime,
+    actor_ref: ActorRef[AnActor],
+) -> None:
     event = runtime.event_class()
 
     actor_ref.tell({"command": "callback", "callback": event.wait})
@@ -83,7 +104,10 @@ def test_messages_left_in_queue_after_actor_stops_receive_an_error(runtime, acto
         response.get(timeout=0.5)
 
 
-def test_stop_requests_left_in_queue_after_actor_stops_are_handled(runtime, actor_ref):
+def test_stop_requests_left_in_queue_after_actor_stops_are_handled(
+    runtime: Runtime,
+    actor_ref: ActorRef[AnActor],
+) -> None:
     event = runtime.event_class()
 
     actor_ref.tell({"command": "callback", "callback": event.wait})
@@ -94,11 +118,14 @@ def test_stop_requests_left_in_queue_after_actor_stops_are_handled(runtime, acto
     response.get(timeout=0.5)
 
 
-def test_actor_has_an_uuid4_based_urn(actor_ref):
+def test_actor_has_an_uuid4_based_urn(actor_ref: ActorRef[AnActor]) -> None:
     assert uuid.UUID(actor_ref.actor_urn).version == 4
 
 
-def test_actor_has_unique_uuid(actor_class, events):
+def test_actor_has_unique_uuid(
+    actor_class: type[AnActor],
+    events: Events,
+) -> None:
     actors = [actor_class.start(events) for _ in range(3)]
 
     assert actors[0].actor_urn != actors[1].actor_urn
@@ -106,28 +133,40 @@ def test_actor_has_unique_uuid(actor_class, events):
     assert actors[2].actor_urn != actors[0].actor_urn
 
 
-def test_str_on_raw_actor_contains_actor_class_name(actor_class, events):
+def test_str_on_raw_actor_contains_actor_class_name(
+    actor_class: type[AnActor],
+    events: Events,
+) -> None:
     unstarted_actor = actor_class(events)
 
     assert "ActorA" in str(unstarted_actor)
 
 
-def test_str_on_raw_actor_contains_actor_urn(actor_class, events):
+def test_str_on_raw_actor_contains_actor_urn(
+    actor_class: type[AnActor],
+    events: Events,
+) -> None:
     unstarted_actor = actor_class(events)
 
     assert unstarted_actor.actor_urn in str(unstarted_actor)
 
 
-def test_init_can_be_called_with_arbitrary_arguments(runtime):
+def test_init_can_be_called_with_arbitrary_arguments(runtime: Runtime) -> None:
     runtime.actor_class(1, 2, 3, foo="bar")
 
 
-def test_on_start_is_called_before_first_message_is_processed(actor_ref, events):
+def test_on_start_is_called_before_first_message_is_processed(
+    actor_ref: ActorRef[AnActor],
+    events: Events,
+) -> None:
     events.on_start_was_called.wait(5)
     assert events.on_start_was_called.is_set()
 
 
-def test_on_start_is_called_after_the_actor_is_registered(actor_ref, events):
+def test_on_start_is_called_after_the_actor_is_registered(
+    actor_ref: ActorRef[AnActor],
+    events: Events,
+) -> None:
     # NOTE: If the actor is registered after the actor is started, this
     # test may still occasionally pass, as it is dependant on the exact
     # timing of events. When the actor is first registered and then
@@ -140,8 +179,9 @@ def test_on_start_is_called_after_the_actor_is_registered(actor_ref, events):
 
 
 def test_on_start_can_stop_actor_before_receive_loop_is_started(
-    early_stopping_actor_class, events
-):
+    early_stopping_actor_class: type[AnActor],
+    events: Events,
+) -> None:
     # NOTE: This test will pass even if the actor is allowed to start the
     # receive loop, but it will cause the test suite to hang, as the actor
     # thread is blocking on receiving messages to the actor inbox forever.
@@ -155,7 +195,10 @@ def test_on_start_can_stop_actor_before_receive_loop_is_started(
     assert not actor_ref.is_alive()
 
 
-def test_on_start_failure_causes_actor_to_stop(early_failing_actor_class, events):
+def test_on_start_failure_causes_actor_to_stop(
+    early_failing_actor_class: type[AnActor],
+    events: Events,
+) -> None:
     # Actor should not be alive if on_start fails.
 
     actor_ref = early_failing_actor_class.start(events)
@@ -165,7 +208,10 @@ def test_on_start_failure_causes_actor_to_stop(early_failing_actor_class, events
     assert not actor_ref.is_alive()
 
 
-def test_on_stop_is_called_when_actor_is_stopped(actor_ref, events):
+def test_on_stop_is_called_when_actor_is_stopped(
+    actor_ref: ActorRef[AnActor],
+    events: Events,
+) -> None:
     assert not events.on_stop_was_called.is_set()
 
     actor_ref.stop()
@@ -174,14 +220,20 @@ def test_on_stop_is_called_when_actor_is_stopped(actor_ref, events):
     assert events.on_stop_was_called.is_set()
 
 
-def test_on_stop_failure_causes_actor_to_stop(late_failing_actor_class, events):
+def test_on_stop_failure_causes_actor_to_stop(
+    late_failing_actor_class: type[AnActor],
+    events: Events,
+) -> None:
     actor_ref = late_failing_actor_class.start(events)
 
     events.on_stop_was_called.wait(5)
     assert not actor_ref.is_alive()
 
 
-def test_on_failure_is_called_when_exception_cannot_be_returned(actor_ref, events):
+def test_on_failure_is_called_when_exception_cannot_be_returned(
+    actor_ref: ActorRef[AnActor],
+    events: Events,
+) -> None:
     assert not events.on_failure_was_called.is_set()
 
     actor_ref.tell({"command": "raise exception"})
@@ -192,8 +244,9 @@ def test_on_failure_is_called_when_exception_cannot_be_returned(actor_ref, event
 
 
 def test_on_failure_failure_causes_actor_to_stop(
-    failing_on_failure_actor_class, events
-):
+    failing_on_failure_actor_class: type[AnActor],
+    events: Events,
+) -> None:
     actor_ref = failing_on_failure_actor_class.start(events)
 
     actor_ref.tell({"command": "raise exception"})
@@ -202,7 +255,10 @@ def test_on_failure_failure_causes_actor_to_stop(
     assert not actor_ref.is_alive()
 
 
-def test_actor_is_stopped_when_unhandled_exceptions_are_raised(actor_ref, events):
+def test_actor_is_stopped_when_unhandled_exceptions_are_raised(
+    actor_ref: ActorRef[AnActor],
+    events: Events,
+) -> None:
     assert not events.on_failure_was_called.is_set()
 
     actor_ref.tell({"command": "raise exception"})
@@ -212,7 +268,10 @@ def test_actor_is_stopped_when_unhandled_exceptions_are_raised(actor_ref, events
     assert len(ActorRegistry.get_all()) == 0
 
 
-def test_all_actors_are_stopped_on_base_exception(events, actor_ref):
+def test_all_actors_are_stopped_on_base_exception(
+    actor_ref: ActorRef[AnActor],
+    events: Events,
+) -> None:
     assert len(ActorRegistry.get_all()) == 1
     assert not events.on_stop_was_called.is_set()
 
@@ -227,11 +286,16 @@ def test_all_actors_are_stopped_on_base_exception(events, actor_ref):
     assert len(ActorRegistry.get_all()) == 0
 
 
-def test_actor_can_call_stop_on_self_multiple_times(actor_ref):
+def test_actor_can_call_stop_on_self_multiple_times(
+    actor_ref: ActorRef[AnActor],
+) -> None:
     actor_ref.ask({"command": "stop twice"})
 
 
-def test_actor_processes_all_messages_before_stop_on_self_stops_it(actor_ref, events):
+def test_actor_processes_all_messages_before_stop_on_self_stops_it(
+    actor_ref: ActorRef[AnActor],
+    events: Events,
+) -> None:
     actor_ref.ask({"command": "message self then stop"})
 
     events.greetings_was_received.wait(5)

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,7 +1,8 @@
+from pykka import Future
 from pykka._envelope import Envelope
 
 
-def test_envelope_repr():
-    envelope = Envelope("message", reply_to=123)
+def test_envelope_repr() -> None:
+    envelope = Envelope("message", reply_to=Future())
 
-    assert repr(envelope) == "Envelope(message='message', reply_to=123)"
+    assert repr(envelope) == "Envelope(message='message', reply_to=<pykka.Future>)"

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -1,47 +1,59 @@
+from __future__ import annotations
+
 import asyncio
 import sys
 import traceback
+from typing import TYPE_CHECKING, Any, Generator, Iterable, List
 
 import pytest
 
 from pykka import Future, Timeout, get_all
 
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
-def run_async(coroutine):
+    from tests.types import Runtime
+
+
+def run_async(coroutine: Any) -> Any:
     loop = asyncio.get_event_loop()
     f = asyncio.ensure_future(coroutine, loop=loop)
     return loop.run_until_complete(f)
 
 
-def test_base_future_get_is_not_implemented():
-    future = Future()
+def test_base_future_get_is_not_implemented() -> None:
+    future: Future[Any] = Future()
 
     with pytest.raises(NotImplementedError):
         future.get()
 
 
-def test_base_future_set_is_not_implemented():
-    future = Future()
+def test_base_future_set_is_not_implemented() -> None:
+    future: Future[Any] = Future()
 
     with pytest.raises(NotImplementedError):
         future.set(None)
 
 
-def test_base_future_set_exception_is_not_implemented():
-    future = Future()
+def test_base_future_set_exception_is_not_implemented() -> None:
+    future: Future[Any] = Future()
 
     with pytest.raises(NotImplementedError):
         future.set_exception(None)
 
 
-def test_set_multiple_times_fails(future):
+def test_set_multiple_times_fails(
+    future: Future[int],
+) -> None:
     future.set(0)
 
     with pytest.raises(Exception):  # noqa: B017, PT011
         future.set(0)
 
 
-def test_get_all_blocks_until_all_futures_are_available(futures):
+def test_get_all_blocks_until_all_futures_are_available(
+    futures: list[Future[int]],
+) -> None:
     futures[0].set(0)
     futures[1].set(1)
     futures[2].set(2)
@@ -51,7 +63,9 @@ def test_get_all_blocks_until_all_futures_are_available(futures):
     assert result == [0, 1, 2]
 
 
-def test_get_all_raises_timeout_if_not_all_futures_are_available(futures):
+def test_get_all_raises_timeout_if_not_all_futures_are_available(
+    futures: list[Future[int]],
+) -> None:
     futures[0].set(0)
     futures[1].set(1)
     # futures[2] has not been set
@@ -60,7 +74,9 @@ def test_get_all_raises_timeout_if_not_all_futures_are_available(futures):
         get_all(futures, timeout=0)
 
 
-def test_get_all_can_be_called_multiple_times(futures):
+def test_get_all_can_be_called_multiple_times(
+    futures: list[Future[int]],
+) -> None:
     futures[0].set(0)
     futures[1].set(1)
     futures[2].set(2)
@@ -71,7 +87,7 @@ def test_get_all_can_be_called_multiple_times(futures):
     assert result1 == result2
 
 
-def test_future_in_future_works(runtime):
+def test_future_in_future_works(runtime: Runtime) -> None:
     inner_future = runtime.future_class()
     inner_future.set("foo")
 
@@ -81,7 +97,7 @@ def test_future_in_future_works(runtime):
     assert outer_future.get().get() == "foo"
 
 
-def test_get_raises_exception_with_full_traceback(runtime):
+def test_get_raises_exception_with_full_traceback(runtime: Runtime) -> None:
     exc_class_get = None
     exc_class_set = None
     exc_instance_get = None
@@ -116,16 +132,20 @@ def test_get_raises_exception_with_full_traceback(runtime):
         assert frame == exc_traceback_list_get[i]
 
 
-def test_future_supports_await_syntax(future):
-    async def get_value():
+def test_future_supports_await_syntax(
+    future: Future[int],
+) -> None:
+    async def get_value() -> int:
         return await future
 
     future.set(1)
     assert run_async(get_value()) == 1
 
 
-def test_future_supports_yield_from_syntax(future):
-    def get_value():
+def test_future_supports_yield_from_syntax(
+    future: Future[int],
+) -> None:
+    def get_value() -> Generator[None, None, int]:
         val = yield from future
         return val
 
@@ -133,29 +153,38 @@ def test_future_supports_yield_from_syntax(future):
     assert run_async(get_value()) == 1
 
 
-def test_filter_excludes_items_not_matching_predicate(future):
+def test_filter_excludes_items_not_matching_predicate(
+    future: Future[Iterable[int]],
+) -> None:
     filtered = future.filter(lambda x: x > 10)
     future.set([1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
 
     assert filtered.get(timeout=0) == [11, 13, 15, 17, 19]
 
 
-def test_filter_on_noniterable(future):
-    filtered = future.filter(lambda x: x > 10)
+def test_filter_on_noniterable(
+    future: Future[int],
+) -> None:
+    filtered = future.filter(lambda x: x > 10)  # type: ignore  # noqa: PGH003
     future.set(1)
 
     with pytest.raises(TypeError):
         filtered.get(timeout=0)
 
 
-def test_filter_preserves_the_timeout_kwarg(future):
+def test_filter_preserves_the_timeout_kwarg(
+    future: Future[Iterable[int]],
+) -> None:
     filtered = future.filter(lambda x: x > 10)
 
     with pytest.raises(Timeout):
         filtered.get(timeout=0)
 
 
-def test_filter_reuses_result_if_called_multiple_times(future, mocker):
+def test_filter_reuses_result_if_called_multiple_times(
+    future: Future[Iterable[int]],
+    mocker: MockerFixture,
+) -> None:
     raise_on_reuse_func = mocker.Mock(side_effect=[False, True, Exception])
 
     filtered = future.filter(raise_on_reuse_func)
@@ -166,7 +195,9 @@ def test_filter_reuses_result_if_called_multiple_times(future, mocker):
     assert filtered.get(timeout=0) == [2]  # First result is reused
 
 
-def test_join_combines_multiple_futures_into_one(futures):
+def test_join_combines_multiple_futures_into_one(
+    futures: List[Future[int]],
+) -> None:
     joined = futures[0].join(futures[1], futures[2])
     futures[0].set(0)
     futures[1].set(1)
@@ -175,7 +206,9 @@ def test_join_combines_multiple_futures_into_one(futures):
     assert joined.get(timeout=0) == [0, 1, 2]
 
 
-def test_join_preserves_timeout_kwarg(futures):
+def test_join_preserves_timeout_kwarg(
+    futures: List[Future[int]],
+) -> None:
     joined = futures[0].join(futures[1], futures[2])
     futures[0].set(0)
     futures[1].set(1)
@@ -185,14 +218,18 @@ def test_join_preserves_timeout_kwarg(futures):
         joined.get(timeout=0)
 
 
-def test_map_returns_future_which_passes_result_through_func(future):
+def test_map_returns_future_which_passes_result_through_func(
+    future: Future[int],
+) -> None:
     mapped = future.map(lambda x: x + 10)
     future.set(30)
 
     assert mapped.get(timeout=0) == 40
 
 
-def test_map_works_on_dict(future):
+def test_map_works_on_dict(
+    future: Future[dict[str, str]],
+) -> None:
     # Regression test for issue #64
 
     mapped = future.map(lambda x: x["foo"])
@@ -201,26 +238,33 @@ def test_map_works_on_dict(future):
     assert mapped.get(timeout=0) == "bar"
 
 
-def test_map_does_not_map_each_value_in_futures_iterable_result(future):
+def test_map_does_not_map_each_value_in_futures_iterable_result(
+    future: Future[Iterable[int]],
+) -> None:
     # Behavior changed in Pykka 2.0:
     # This used to map each value in the future's result through the func,
     # yielding [20, 30, 40].
 
-    mapped = future.map(lambda x: x + 10)
+    mapped = future.map(lambda x: x + 10)  # type: ignore  # noqa: PGH003
     future.set([10, 20, 30])
 
     with pytest.raises(TypeError):
         mapped.get(timeout=0)
 
 
-def test_map_preserves_timeout_kwarg(future):
+def test_map_preserves_timeout_kwarg(
+    future: Future[int],
+) -> None:
     mapped = future.map(lambda x: x + 10)
 
     with pytest.raises(Timeout):
         mapped.get(timeout=0)
 
 
-def test_map_reuses_result_if_called_multiple_times(future, mocker):
+def test_map_reuses_result_if_called_multiple_times(
+    future: Future[int],
+    mocker: MockerFixture,
+) -> None:
     raise_on_reuse_func = mocker.Mock(side_effect=[10, Exception])
 
     mapped = future.map(raise_on_reuse_func)
@@ -230,36 +274,47 @@ def test_map_reuses_result_if_called_multiple_times(future, mocker):
     assert mapped.get(timeout=0) == 10  # First result is reused
 
 
-def test_reduce_applies_function_cumulatively_from_the_left(future):
-    reduced = future.reduce(lambda x, y: x + y)
+def test_reduce_applies_function_cumulatively_from_the_left(
+    future: Future[Iterable[int]],
+) -> None:
+    reduced: Future[int] = future.reduce(lambda x, y: x + y)
     future.set([1, 2, 3, 4])
 
     assert reduced.get(timeout=0) == 10
 
 
-def test_reduce_accepts_an_initial_value(future):
+def test_reduce_accepts_an_initial_value(
+    future: Future[Iterable[int]],
+) -> None:
     reduced = future.reduce(lambda x, y: x + y, 5)
     future.set([1, 2, 3, 4])
 
     assert reduced.get(timeout=0) == 15
 
 
-def test_reduce_on_noniterable(future):
-    reduced = future.reduce(lambda x, y: x + y)
+def test_reduce_on_noniterable(
+    future: Future[int],
+) -> None:
+    reduced = future.reduce(lambda x, y: x + y)  # type: ignore  # noqa: PGH003
     future.set(1)
 
     with pytest.raises(TypeError):
         reduced.get(timeout=0)
 
 
-def test_reduce_preserves_the_timeout_kwarg(future):
-    reduced = future.reduce(lambda x, y: x + y)
+def test_reduce_preserves_the_timeout_kwarg(
+    future: Future[Iterable[int]],
+) -> None:
+    reduced: Future[int] = future.reduce(lambda x, y: x + y)
 
     with pytest.raises(Timeout):
         reduced.get(timeout=0)
 
 
-def test_reduce_reuses_result_if_called_multiple_times(future, mocker):
+def test_reduce_reuses_result_if_called_multiple_times(
+    future: Future[Iterable[int]],
+    mocker: MockerFixture,
+) -> None:
     raise_on_reuse_func = mocker.Mock(side_effect=[3, 6, Exception])
 
     reduced = future.reduce(raise_on_reuse_func)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,97 +1,137 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, Any, Iterator, NoReturn, Optional
 
 import pytest
+
+from pykka import Actor
+from tests.log_handler import LogLevel, PykkaTestLogHandler
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from pykka import ActorRef
+    from tests.types import Events, Runtime
 
 pytestmark = pytest.mark.usefixtures("_stop_all")
 
 
+class LoggingActor(Actor):
+    def __init__(self, events: Events) -> None:
+        super().__init__()
+        self.events = events
+
+    def on_stop(self) -> None:
+        self.events.on_stop_was_called.set()
+
+    def on_failure(
+        self,
+        exception_type: Optional[type[BaseException]],
+        exception_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.events.on_failure_was_called.set()
+
+    def on_receive(self, message: Any) -> Any:
+        if message.get("command") == "raise exception":
+            return self.raise_exception()
+        if message.get("command") == "raise base exception":
+            raise BaseException
+        return super().on_receive(message)
+
+    def raise_exception(self) -> NoReturn:
+        raise Exception("foo")
+
+
 @pytest.fixture(scope="module")
-def actor_class(runtime):
-    class ActorA(runtime.actor_class):
-        def __init__(self, events):
-            super().__init__()
-            self.events = events
+def actor_class(runtime: Runtime) -> type[LoggingActor]:
+    class LoggingActorImpl(LoggingActor, runtime.actor_class):  # type: ignore[name-defined]  # noqa: E501
+        pass
 
-        def on_stop(self):
-            self.events.on_stop_was_called.set()
-
-        def on_failure(self, exception_type, exception_value, traceback):
-            self.events.on_failure_was_called.set()
-
-        def on_receive(self, message):
-            if message.get("command") == "raise exception":
-                return self.raise_exception()
-            if message.get("command") == "raise base exception":
-                raise BaseException
-            return super().on_receive(message)
-
-        def raise_exception(self):
-            raise Exception("foo")
-
-    return ActorA
+    return LoggingActorImpl
 
 
 @pytest.fixture()
-def actor_ref(actor_class, events):
+def actor_ref(
+    actor_class: type[LoggingActor],
+    events: Events,
+) -> Iterator[ActorRef[LoggingActor]]:
     ref = actor_class.start(events)
     yield ref
     ref.stop()
 
 
-def test_null_handler_is_added_to_avoid_warnings():
+def test_null_handler_is_added_to_avoid_warnings() -> None:
     logger = logging.getLogger("pykka")
     handler_names = [h.__class__.__name__ for h in logger.handlers]
 
     assert "NullHandler" in handler_names
 
 
-def test_unexpected_messages_are_logged(actor_ref, log_handler):
+def test_unexpected_messages_are_logged(
+    actor_ref: ActorRef[LoggingActor],
+    log_handler: PykkaTestLogHandler,
+) -> None:
     actor_ref.ask({"unhandled": "message"})
 
-    log_handler.wait_for_message("warning")
+    log_handler.wait_for_message(LogLevel.WARNING)
     with log_handler.lock:
-        assert len(log_handler.messages["warning"]) == 1
-        log_record = log_handler.messages["warning"][0]
+        assert len(log_handler.messages[LogLevel.WARNING]) == 1
+        log_record = log_handler.messages[LogLevel.WARNING][0]
 
     assert log_record.getMessage().split(": ")[0] == (
         f"Unexpected message received by {actor_ref}"
     )
 
 
-def test_exception_is_logged_when_returned_to_caller(actor_ref, log_handler):
+def test_exception_is_logged_when_returned_to_caller(
+    actor_ref: ActorRef[LoggingActor],
+    log_handler: PykkaTestLogHandler,
+) -> None:
     with pytest.raises(Exception, match="foo"):
         actor_ref.proxy().raise_exception().get()
 
-    log_handler.wait_for_message("info")
+    log_handler.wait_for_message(LogLevel.INFO)
     with log_handler.lock:
-        assert len(log_handler.messages["info"]) == 1
-        log_record = log_handler.messages["info"][0]
+        assert len(log_handler.messages[LogLevel.INFO]) == 1
+        log_record = log_handler.messages[LogLevel.INFO][0]
 
     assert log_record.getMessage() == (
         f"Exception returned from {actor_ref} to caller:"
     )
+    assert log_record.exc_info
     assert log_record.exc_info[0] == Exception
     assert str(log_record.exc_info[1]) == "foo"
 
 
-def test_exception_is_logged_when_not_reply_requested(actor_ref, events, log_handler):
+def test_exception_is_logged_when_not_reply_requested(
+    actor_ref: ActorRef[LoggingActor],
+    events: Events,
+    log_handler: PykkaTestLogHandler,
+) -> None:
     events.on_failure_was_called.clear()
     actor_ref.tell({"command": "raise exception"})
 
     events.on_failure_was_called.wait(5)
     assert events.on_failure_was_called.is_set()
 
-    log_handler.wait_for_message("error")
+    log_handler.wait_for_message(LogLevel.ERROR)
     with log_handler.lock:
-        assert len(log_handler.messages["error"]) == 1
-        log_record = log_handler.messages["error"][0]
+        assert len(log_handler.messages[LogLevel.ERROR]) == 1
+        log_record = log_handler.messages[LogLevel.ERROR][0]
 
     assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"
+    assert log_record.exc_info
     assert log_record.exc_info[0] == Exception
     assert str(log_record.exc_info[1]) == "foo"
 
 
-def test_base_exception_is_logged(actor_ref, events, log_handler):
+def test_base_exception_is_logged(
+    actor_ref: ActorRef[LoggingActor],
+    events: Events,
+    log_handler: PykkaTestLogHandler,
+) -> None:
     log_handler.reset()
     events.on_stop_was_called.clear()
     actor_ref.tell({"command": "raise base exception"})
@@ -99,10 +139,10 @@ def test_base_exception_is_logged(actor_ref, events, log_handler):
     events.on_stop_was_called.wait(5)
     assert events.on_stop_was_called.is_set()
 
-    log_handler.wait_for_message("debug", num_messages=3)
+    log_handler.wait_for_message(LogLevel.DEBUG, num_messages=3)
     with log_handler.lock:
-        assert len(log_handler.messages["debug"]) == 3
-        log_record = log_handler.messages["debug"][0]
+        assert len(log_handler.messages[LogLevel.DEBUG]) == 3
+        log_record = log_handler.messages[LogLevel.DEBUG][0]
 
     assert log_record.getMessage() == (
         f"BaseException() in {actor_ref}. Stopping all actors."
@@ -110,44 +150,52 @@ def test_base_exception_is_logged(actor_ref, events, log_handler):
 
 
 def test_exception_in_on_start_is_logged(
-    early_failing_actor_class, events, log_handler
-):
+    early_failing_actor_class: type[LoggingActor],
+    events: Events,
+    log_handler: PykkaTestLogHandler,
+) -> None:
     log_handler.reset()
     actor_ref = early_failing_actor_class.start(events)
     events.on_start_was_called.wait(5)
 
-    log_handler.wait_for_message("error")
+    log_handler.wait_for_message(LogLevel.ERROR)
     with log_handler.lock:
-        assert len(log_handler.messages["error"]) == 1
-        log_record = log_handler.messages["error"][0]
+        assert len(log_handler.messages[LogLevel.ERROR]) == 1
+        log_record = log_handler.messages[LogLevel.ERROR][0]
 
     assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"
 
 
-def test_exception_in_on_stop_is_logged(late_failing_actor_class, events, log_handler):
+def test_exception_in_on_stop_is_logged(
+    late_failing_actor_class: type[LoggingActor],
+    events: Events,
+    log_handler: PykkaTestLogHandler,
+) -> None:
     log_handler.reset()
     actor_ref = late_failing_actor_class.start(events)
     events.on_stop_was_called.wait(5)
 
-    log_handler.wait_for_message("error")
+    log_handler.wait_for_message(LogLevel.ERROR)
     with log_handler.lock:
-        assert len(log_handler.messages["error"]) == 1
-        log_record = log_handler.messages["error"][0]
+        assert len(log_handler.messages[LogLevel.ERROR]) == 1
+        log_record = log_handler.messages[LogLevel.ERROR][0]
 
     assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"
 
 
 def test_exception_in_on_failure_is_logged(
-    failing_on_failure_actor_class, events, log_handler
-):
+    failing_on_failure_actor_class: type[LoggingActor],
+    events: Events,
+    log_handler: PykkaTestLogHandler,
+) -> None:
     log_handler.reset()
     actor_ref = failing_on_failure_actor_class.start(events)
     actor_ref.tell({"command": "raise exception"})
     events.on_failure_was_called.wait(5)
 
-    log_handler.wait_for_message("error", num_messages=2)
+    log_handler.wait_for_message(LogLevel.ERROR, num_messages=2)
     with log_handler.lock:
-        assert len(log_handler.messages["error"]) == 2
-        log_record = log_handler.messages["error"][0]
+        assert len(log_handler.messages[LogLevel.ERROR]) == 2
+        log_record = log_handler.messages[LogLevel.ERROR][0]
 
     assert log_record.getMessage() == f"Unhandled exception in {actor_ref}:"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,29 +1,29 @@
 from pykka.messages import ProxyCall, ProxyGetAttr, ProxySetAttr, _ActorStop
 
 
-def test_actor_stop():
+def test_actor_stop() -> None:
     message = _ActorStop()
 
     assert isinstance(message, _ActorStop)
 
 
-def test_proxy_call():
-    message = ProxyCall(attr_path=["nested", "method"], args=[1], kwargs={"a": "b"})
+def test_proxy_call() -> None:
+    message = ProxyCall(attr_path=["nested", "method"], args=(1,), kwargs={"a": "b"})
 
     assert isinstance(message, ProxyCall)
     assert message.attr_path == ["nested", "method"]
-    assert message.args == [1]
+    assert message.args == (1,)
     assert message.kwargs == {"a": "b"}
 
 
-def test_proxy_get_attr():
+def test_proxy_get_attr() -> None:
     message = ProxyGetAttr(attr_path=["nested", "attr"])
 
     assert isinstance(message, ProxyGetAttr)
     assert message.attr_path == ["nested", "attr"]
 
 
-def test_proxy_set_attr():
+def test_proxy_set_attr() -> None:
     message = ProxySetAttr(attr_path=["nested", "attr"], value="abcdef")
 
     assert isinstance(message, ProxySetAttr)

--- a/tests/test_threading_actor.py
+++ b/tests/test_threading_actor.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 import threading
+from typing import TYPE_CHECKING, Iterator
 
 import pytest
 
 from pykka import ThreadingActor
+
+if TYPE_CHECKING:
+    from pykka import ActorRef
 
 
 class RegularActor(ThreadingActor):
@@ -14,20 +20,22 @@ class DaemonActor(ThreadingActor):
 
 
 @pytest.fixture()
-def regular_actor_ref():
+def regular_actor_ref() -> Iterator[ActorRef[RegularActor]]:
     ref = RegularActor.start()
     yield ref
     ref.stop()
 
 
 @pytest.fixture()
-def daemon_actor_ref():
+def daemon_actor_ref() -> Iterator[ActorRef[DaemonActor]]:
     ref = DaemonActor.start()
     yield ref
     ref.stop()
 
 
-def test_actor_thread_is_named_after_pykka_actor_class(regular_actor_ref):
+def test_actor_thread_is_named_after_pykka_actor_class(
+    regular_actor_ref: ActorRef[RegularActor],
+) -> None:
     alive_threads = threading.enumerate()
     alive_thread_names = [t.name for t in alive_threads]
     named_correctly = [
@@ -37,7 +45,9 @@ def test_actor_thread_is_named_after_pykka_actor_class(regular_actor_ref):
     assert any(named_correctly)
 
 
-def test_actor_thread_is_not_daemonic_by_default(regular_actor_ref):
+def test_actor_thread_is_not_daemonic_by_default(
+    regular_actor_ref: ActorRef[RegularActor],
+) -> None:
     alive_threads = threading.enumerate()
     actor_threads = [t for t in alive_threads if t.name.startswith("RegularActor")]
 
@@ -46,8 +56,8 @@ def test_actor_thread_is_not_daemonic_by_default(regular_actor_ref):
 
 
 def test_actor_thread_is_daemonic_if_use_daemon_thread_flag_is_set(
-    daemon_actor_ref,
-):
+    daemon_actor_ref: ActorRef[DaemonActor],
+) -> None:
     alive_threads = threading.enumerate()
     actor_threads = [t for t in alive_threads if t.name.startswith("DaemonActor")]
 

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol
+
+if TYPE_CHECKING:
+    from pykka import Actor, Future
+
+
+class Event(Protocol):
+    def clear(self) -> None:
+        ...
+
+    def is_set(self) -> bool:
+        ...
+
+    def set(self) -> None:
+        ...
+
+    def wait(self, timeout: Optional[float] = None) -> bool:
+        ...
+
+
+@dataclass
+class Events:
+    on_start_was_called: Event
+    on_stop_was_called: Event
+    on_failure_was_called: Event
+    greetings_was_received: Event
+    actor_registered_before_on_start_was_called: Event
+
+
+@dataclass
+class Runtime:
+    name: str
+    actor_class: type[Actor]
+    event_class: type[Event]
+    future_class: type[Future[Any]]
+    sleep_func: Callable[[float], None]

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
 [testenv:pyright]
 commands =
     poetry install --only=main,dev,docs,tests,pyright
-    poetry run pyright src
+    poetry run pyright src tests
 
 [testenv:ruff]
 commands =


### PR DESCRIPTION
- Upgrade pyright to 1.1.313
- Name type vars consistently
- Make `ActorRef` and `ActorProxy` generic
- Change the return type of `ActorProxy.__getattr__()` to `Any`
- Fully type test suite
