### PR TITLE
registry (threading): fix broken but passing test

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -213,28 +213,40 @@ def test_broadcast_sends_message_to_all_actors_if_no_target(
 def test_broadcast_sends_message_to_all_actors_of_given_class(
     actor_a_class: type[ActorA],
     actor_b_class: type[ActorA],
+    a_actor_refs: list[ActorRef[ActorA]],
+    b_actor_refs: list[ActorRef[ActorB]],
 ) -> None:
     ActorRegistry.broadcast({"command": "foo"}, target_class=actor_a_class)
 
-    for actor_ref in ActorRegistry.get_by_class(actor_a_class):
-        received_messages = actor_ref.proxy().received_messages.get()
+    class_a_refs = ActorRegistry.get_by_class(actor_a_class)
+    assert set(class_a_refs) == set(a_actor_refs)
+    for actor_a_ref in class_a_refs:
+        received_messages = actor_a_ref.proxy().received_messages.get()
         assert {"command": "foo"} in received_messages
 
-    for actor_ref in ActorRegistry.get_by_class(actor_b_class):
-        received_messages = actor_ref.proxy().received_messages.get()
+    class_b_refs = ActorRegistry.get_by_class(actor_b_class)
+    assert set(class_b_refs) == set(b_actor_refs)
+    for actor_b_ref in class_b_refs:
+        received_messages = actor_b_ref.proxy().received_messages.get()
         assert {"command": "foo"} not in received_messages
 
 
 def test_broadcast_sends_message_to_all_actors_of_given_class_name(
     actor_a_class: type[ActorA],
     actor_b_class: type[ActorB],
+    a_actor_refs: list[ActorRef[ActorA]],
+    b_actor_refs: list[ActorRef[ActorB]],
 ) -> None:
-    ActorRegistry.broadcast({"command": "foo"}, target_class="ActorA")
+    ActorRegistry.broadcast({"command": "foo"}, target_class="ActorAImpl")
 
-    for actor_a_ref in ActorRegistry.get_by_class(actor_a_class):
+    class_a_refs = ActorRegistry.get_by_class_name("ActorAImpl")
+    assert set(class_a_refs) == set(a_actor_refs)
+    for actor_a_ref in class_a_refs:
         received_messages = actor_a_ref.proxy().received_messages.get()
         assert {"command": "foo"} in received_messages
 
-    for actor_b_ref in ActorRegistry.get_by_class(actor_b_class):
+    class_b_refs = ActorRegistry.get_by_class_name("ActorBImpl")
+    assert set(class_b_refs) == set(b_actor_refs)
+    for actor_b_ref in class_b_refs:
         received_messages = actor_b_ref.proxy().received_messages.get()
         assert {"command": "foo"} not in received_messages

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -212,7 +212,7 @@ def test_broadcast_sends_message_to_all_actors_if_no_target(
 
 def test_broadcast_sends_message_to_all_actors_of_given_class(
     actor_a_class: type[ActorA],
-    actor_b_class: type[ActorA],
+    actor_b_class: type[ActorB],
     a_actor_refs: list[ActorRef[ActorA]],
     b_actor_refs: list[ActorRef[ActorB]],
 ) -> None:


### PR DESCRIPTION
Hello, while hacking on your framework I noticed these two tests were passing when they shouldn't have been. I realized that in both cases the tests were missing the actor ref fixture parameters, so no actors were ever added to the registry. The assertions inside the loops over the actor refs retrieved from the registry consequently never ran!

I've added the missing actor refs to both tests, plus some additional asserts to cover that the registry contains the expected actors.

Thanks for writing this excellent library (the code is extremely pleasant to work with, I can learn a lot from this). I hope you find this contribution useful.