### PR TITLE
Reimplement `ThreadingFuture[T]` to use condition variable instead of queue

### DIFF
--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -3,15 +3,7 @@ from __future__ import annotations
 import contextlib
 import functools
 from collections.abc import Callable, Generator, Iterable
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Generic,
-    TypeAlias,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, cast
 
 if TYPE_CHECKING:
     from pykka._types import OptExcInfo
@@ -36,19 +28,21 @@ class Future(Generic[T]):
     ``await`` the future.
     """
 
-    _NULL_CONTEXT: ClassVar[contextlib.AbstractContextManager[bool]] = (
-        contextlib.nullcontext(enter_result=True)
-    )
-
     _context_manager: contextlib.AbstractContextManager[bool]
     _get_hook: GetHookFunc[T] | None
     _get_hook_result: T | None
 
     def __init__(
-        self, context_manager: contextlib.AbstractContextManager[bool] = _NULL_CONTEXT
+        self,
+        *,
+        context_manager: contextlib.AbstractContextManager[bool] | None = None,
     ) -> None:
         super().__init__()
-        self._context_manager = context_manager
+        self._context_manager = (
+            context_manager
+            if context_manager is not None
+            else contextlib.nullcontext(enter_result=True)
+        )
         self._get_hook = None
         self._get_hook_result = None
 

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -80,13 +80,6 @@ class Future(Generic[T]):
         :raise: encapsulated value if it is an exception
         :return: encapsulated value if it is not an exception
         """
-        if isinstance(self._context_manager, contextlib.nullcontext):
-            if self._get_hook is not None:
-                if self._get_hook_result is None:
-                    self._get_hook_result = self._get_hook(timeout)
-                return self._get_hook_result
-            raise NotImplementedError
-
         hook: GetHookFunc[T]
         hook_result: T
 
@@ -100,12 +93,10 @@ class Future(Generic[T]):
         hook_result = hook(timeout)
 
         with self._context_manager:
-            if self._get_hook is not None:
-                if self._get_hook_result is None:
-                    self._get_hook_result = hook_result
-                return self._get_hook_result
-
-        raise NotImplementedError
+            assert self._get_hook is not None
+            if self._get_hook_result is None:
+                self._get_hook_result = hook_result
+            return hook_result
 
     def set(
         self,

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -81,7 +81,6 @@ class Future(Generic[T]):
         :return: encapsulated value if it is not an exception
         """
         hook: GetHookFunc[T]
-        hook_result: T
 
         with self._context_manager:
             if self._get_hook is None:
@@ -96,7 +95,7 @@ class Future(Generic[T]):
             assert self._get_hook is not None
             if self._get_hook_result is None:
                 self._get_hook_result = hook_result
-            return hook_result
+            return self._get_hook_result
 
     def set(
         self,

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -60,11 +60,13 @@ class ThreadingFuture(Future[T]):
 
         with self._condition:
             while self._result is None:
-                rem = None if deadline is None else deadline - time.monotonic()
-                if rem is not None and rem <= 0.0:
+                remaining = (
+                    deadline - time.monotonic() if deadline is not None else None
+                )
+                if remaining is not None and remaining <= 0.0:
                     msg = f"{timeout} seconds"
                     raise Timeout(msg)
-                self._condition.wait(timeout=rem)
+                self._condition.wait(timeout=remaining)
 
             if self._result.exc_info is not None:
                 (exc_type, exc_value, exc_traceback) = self._result.exc_info

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import queue
 import sys
 import threading
+import time
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeVar
 
 from pykka import Actor, Future, Timeout
@@ -40,9 +41,11 @@ class ThreadingFuture(Future[T]):
     """
 
     def __init__(self) -> None:
-        super().__init__()
-        self._queue: queue.Queue[ThreadingFutureResult] = queue.Queue(maxsize=1)
+        rlock = threading.RLock()
+        super().__init__(context_manager=rlock)
+        self._condition: threading.Condition = threading.Condition(lock=rlock)
         self._result: ThreadingFutureResult | None = None
+        self._waiter_count: int = 0
 
     def get(
         self,
@@ -54,9 +57,21 @@ class ThreadingFuture(Future[T]):
         except NotImplementedError:
             pass
 
-        try:
-            if self._result is None:
-                self._result = self._queue.get(True, timeout)
+        deadline: float | None = None if timeout is None else time.monotonic() + timeout
+
+        with self._condition:
+            while self._result is None:
+                rem = None if deadline is None else deadline - time.monotonic()
+
+                if rem is not None and rem <= 0.0:
+                    msg = f"{timeout} seconds"
+                    raise Timeout(msg)
+
+                self._waiter_count += 1
+                try:
+                    self._condition.wait(timeout=rem)
+                finally:
+                    self._waiter_count -= 1
 
             if self._result.exc_info is not None:
                 (exc_type, exc_value, exc_traceback) = self._result.exc_info
@@ -66,17 +81,19 @@ class ThreadingFuture(Future[T]):
                 if exc_value.__traceback__ is not exc_traceback:
                     raise exc_value.with_traceback(exc_traceback)
                 raise exc_value
-        except queue.Empty:
-            msg = f"{timeout} seconds"
-            raise Timeout(msg) from None
-        else:
+
             return self._result.value
 
     def set(
         self,
         value: Any | None = None,
     ) -> None:
-        self._queue.put(ThreadingFutureResult(value=value), block=False)
+        with self._condition:
+            if self._result is not None:
+                raise queue.Full
+            self._result = ThreadingFutureResult(value=value)
+            if self._waiter_count != 0:
+                self._condition.notify_all()
 
     def set_exception(
         self,
@@ -85,7 +102,13 @@ class ThreadingFuture(Future[T]):
         assert exc_info is None or len(exc_info) == 3
         if exc_info is None:
             exc_info = sys.exc_info()
-        self._queue.put(ThreadingFutureResult(exc_info=exc_info))
+
+        with self._condition:
+            if self._result is not None:
+                raise queue.Full
+            self._result = ThreadingFutureResult(exc_info=exc_info)
+            if self._waiter_count != 0:
+                self._condition.notify_all()
 
 
 class ThreadingActor(Actor):

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -41,9 +41,8 @@ class ThreadingFuture(Future[T]):
     """
 
     def __init__(self) -> None:
-        rlock = threading.RLock()
-        super().__init__(context_manager=rlock)
-        self._condition: threading.Condition = threading.Condition(lock=rlock)
+        self._condition: threading.Condition = threading.Condition()
+        super().__init__(context_manager=self._condition)
         self._result: ThreadingFutureResult | None = None
 
     def get(


### PR DESCRIPTION
Re implement to use `threading.Condition` instead of `queue.Queue` to eliminate the race conditions. Also protects the base class `Future[T]` state (i.e `_get_hook` and `_get_hook_result`) with the lock (if any) passed to it from a derived class. Right now the only derived class is `ThreadingFuture[T]` which passes an `RLock` to `Future[T]`.

Fixes #232 