### PR TITLE
Some more Future/ThreadingFuture changes

### DIFF
--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import contextlib
 import functools
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Generic,
     Optional,
     TypeVar,
@@ -38,11 +40,20 @@ class Future(Generic[T]):
     ``await`` the future.
     """
 
+    _NULL_CONTEXT: ClassVar[contextlib.AbstractContextManager[bool]] = (
+        contextlib.nullcontext(enter_result=True)
+    )
+
+    _context_manager: contextlib.AbstractContextManager[bool]
     _get_hook: Optional[GetHookFunc[T]]
     _get_hook_result: Optional[T]
 
-    def __init__(self) -> None:
+    def __init__(
+            self,
+            context_manager: contextlib.AbstractContextManager[bool] = _NULL_CONTEXT
+        ) -> None:
         super().__init__()
+        self._context_manager = context_manager
         self._get_hook = None
         self._get_hook_result = None
 
@@ -74,10 +85,31 @@ class Future(Generic[T]):
         :raise: encapsulated value if it is an exception
         :return: encapsulated value if it is not an exception
         """
-        if self._get_hook is not None:
-            if self._get_hook_result is None:
-                self._get_hook_result = self._get_hook(timeout)
-            return self._get_hook_result
+        if isinstance(self._context_manager, contextlib.nullcontext):
+            if self._get_hook is not None:
+                if self._get_hook_result is None:
+                    self._get_hook_result = self._get_hook(timeout)
+                return self._get_hook_result
+            raise NotImplementedError
+
+        hook: GetHookFunc[T]
+        hook_result: T
+
+        with self._context_manager:
+            if self._get_hook is None:
+                raise NotImplementedError
+            if self._get_hook_result is not None:
+                return self._get_hook_result
+            hook = self._get_hook
+
+        hook_result = hook(timeout)
+
+        with self._context_manager:
+            if self._get_hook is not None:
+                if self._get_hook_result is None:
+                    self._get_hook_result = hook_result
+                return self._get_hook_result
+
         raise NotImplementedError
 
     def set(
@@ -126,7 +158,8 @@ class Future(Generic[T]):
         :param func: called to produce return value of :meth:`get`
         :type func: function accepting a timeout value
         """
-        self._get_hook = func
+        with self._context_manager:
+            self._get_hook = func
 
     def filter(
         self: Future[Iterable[J]],

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    ClassVar,
     Generic,
     Optional,
     TypeVar,
@@ -40,19 +39,21 @@ class Future(Generic[T]):
     ``await`` the future.
     """
 
-    _NULL_CONTEXT: ClassVar[contextlib.AbstractContextManager[bool]] = (
-        contextlib.nullcontext(enter_result=True)
-    )
-
     _context_manager: contextlib.AbstractContextManager[bool]
     _get_hook: Optional[GetHookFunc[T]]
     _get_hook_result: Optional[T]
 
     def __init__(
-        self, context_manager: contextlib.AbstractContextManager[bool] = _NULL_CONTEXT
+        self,
+        *,
+        context_manager: contextlib.AbstractContextManager[bool] | None = None,
     ) -> None:
         super().__init__()
-        self._context_manager = context_manager
+        self._context_manager = (
+            context_manager
+            if context_manager is not None
+            else contextlib.nullcontext(enter_result=True)
+        )
         self._get_hook = None
         self._get_hook_result = None
 

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -85,13 +85,6 @@ class Future(Generic[T]):
         :raise: encapsulated value if it is an exception
         :return: encapsulated value if it is not an exception
         """
-        if isinstance(self._context_manager, contextlib.nullcontext):
-            if self._get_hook is not None:
-                if self._get_hook_result is None:
-                    self._get_hook_result = self._get_hook(timeout)
-                return self._get_hook_result
-            raise NotImplementedError
-
         hook: GetHookFunc[T]
         hook_result: T
 
@@ -105,12 +98,10 @@ class Future(Generic[T]):
         hook_result = hook(timeout)
 
         with self._context_manager:
-            if self._get_hook is not None:
-                if self._get_hook_result is None:
-                    self._get_hook_result = hook_result
-                return self._get_hook_result
-
-        raise NotImplementedError
+            assert self._get_hook is not None
+            if self._get_hook_result is None:
+                self._get_hook_result = hook_result
+            return hook_result
 
     def set(
         self,

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -49,9 +49,8 @@ class Future(Generic[T]):
     _get_hook_result: Optional[T]
 
     def __init__(
-            self,
-            context_manager: contextlib.AbstractContextManager[bool] = _NULL_CONTEXT
-        ) -> None:
+        self, context_manager: contextlib.AbstractContextManager[bool] = _NULL_CONTEXT
+    ) -> None:
         super().__init__()
         self._context_manager = context_manager
         self._get_hook = None
@@ -86,7 +85,6 @@ class Future(Generic[T]):
         :return: encapsulated value if it is not an exception
         """
         hook: GetHookFunc[T]
-        hook_result: T
 
         with self._context_manager:
             if self._get_hook is None:
@@ -101,7 +99,7 @@ class Future(Generic[T]):
             assert self._get_hook is not None
             if self._get_hook_result is None:
                 self._get_hook_result = hook_result
-            return hook_result
+            return self._get_hook_result
 
     def set(
         self,

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -86,7 +86,6 @@ class ThreadingFuture(Future[T]):
 
             return self._result.value
 
-
     def set(
         self,
         value: Optional[Any] = None,

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import queue
 import sys
 import threading
+import time
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, Optional, TypeVar
 
 from pykka import Actor, Future, Timeout
@@ -40,9 +41,11 @@ class ThreadingFuture(Future[T]):
     """
 
     def __init__(self) -> None:
-        super().__init__()
-        self._queue: queue.Queue[ThreadingFutureResult] = queue.Queue(maxsize=1)
+        rlock = threading.RLock()
+        super().__init__(context_manager=rlock)
+        self._condition: threading.Condition = threading.Condition(lock=rlock)
         self._result: Optional[ThreadingFutureResult] = None
+        self._waiter_count: int = 0
 
     def get(
         self,
@@ -54,9 +57,23 @@ class ThreadingFuture(Future[T]):
         except NotImplementedError:
             pass
 
-        try:
-            if self._result is None:
-                self._result = self._queue.get(True, timeout)
+        deadline: Optional[float] = (
+            None if timeout is None else time.monotonic() + timeout
+        )
+
+        with self._condition:
+            while self._result is None:
+                rem = None if deadline is None else deadline - time.monotonic()
+
+                if rem is not None and rem <= 0.0:
+                    msg = f"{timeout} seconds"
+                    raise Timeout(msg)
+
+                self._waiter_count += 1
+                try:
+                    self._condition.wait(timeout=rem)
+                finally:
+                    self._waiter_count -= 1
 
             if self._result.exc_info is not None:
                 (exc_type, exc_value, exc_traceback) = self._result.exc_info
@@ -66,17 +83,20 @@ class ThreadingFuture(Future[T]):
                 if exc_value.__traceback__ is not exc_traceback:
                     raise exc_value.with_traceback(exc_traceback)
                 raise exc_value
-        except queue.Empty:
-            msg = f"{timeout} seconds"
-            raise Timeout(msg) from None
-        else:
+
             return self._result.value
+
 
     def set(
         self,
         value: Optional[Any] = None,
     ) -> None:
-        self._queue.put(ThreadingFutureResult(value=value), block=False)
+        with self._condition:
+            if self._result is not None:
+                raise queue.Full
+            self._result = ThreadingFutureResult(value=value)
+            if self._waiter_count != 0:
+                self._condition.notify_all()
 
     def set_exception(
         self,
@@ -85,7 +105,13 @@ class ThreadingFuture(Future[T]):
         assert exc_info is None or len(exc_info) == 3
         if exc_info is None:
             exc_info = sys.exc_info()
-        self._queue.put(ThreadingFutureResult(exc_info=exc_info))
+
+        with self._condition:
+            if self._result is not None:
+                raise queue.Full
+            self._result = ThreadingFutureResult(exc_info=exc_info)
+            if self._waiter_count != 0:
+                self._condition.notify_all()
 
 
 class ThreadingActor(Actor):

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -41,9 +41,8 @@ class ThreadingFuture(Future[T]):
     """
 
     def __init__(self) -> None:
-        rlock = threading.RLock()
-        super().__init__(context_manager=rlock)
-        self._condition: threading.Condition = threading.Condition(lock=rlock)
+        self._condition: threading.Condition = threading.Condition()
+        super().__init__(context_manager=self._condition)
         self._result: Optional[ThreadingFutureResult] = None
 
     def get(

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -62,11 +62,13 @@ class ThreadingFuture(Future[T]):
 
         with self._condition:
             while self._result is None:
-                rem = None if deadline is None else deadline - time.monotonic()
-                if rem is not None and rem <= 0.0:
+                remaining = (
+                    deadline - time.monotonic() if deadline is not None else None
+                )
+                if remaining is not None and remaining <= 0.0:
                     msg = f"{timeout} seconds"
                     raise Timeout(msg)
-                self._condition.wait(timeout=rem)
+                self._condition.wait(timeout=remaining)
 
             if self._result.exc_info is not None:
                 (exc_type, exc_value, exc_traceback) = self._result.exc_info

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -45,7 +45,6 @@ class ThreadingFuture(Future[T]):
         super().__init__(context_manager=rlock)
         self._condition: threading.Condition = threading.Condition(lock=rlock)
         self._result: Optional[ThreadingFutureResult] = None
-        self._waiter_count: int = 0
 
     def get(
         self,
@@ -64,16 +63,10 @@ class ThreadingFuture(Future[T]):
         with self._condition:
             while self._result is None:
                 rem = None if deadline is None else deadline - time.monotonic()
-
                 if rem is not None and rem <= 0.0:
                     msg = f"{timeout} seconds"
                     raise Timeout(msg)
-
-                self._waiter_count += 1
-                try:
-                    self._condition.wait(timeout=rem)
-                finally:
-                    self._waiter_count -= 1
+                self._condition.wait(timeout=rem)
 
             if self._result.exc_info is not None:
                 (exc_type, exc_value, exc_traceback) = self._result.exc_info
@@ -94,8 +87,7 @@ class ThreadingFuture(Future[T]):
             if self._result is not None:
                 raise queue.Full
             self._result = ThreadingFutureResult(value=value)
-            if self._waiter_count != 0:
-                self._condition.notify_all()
+            self._condition.notify_all()
 
     def set_exception(
         self,
@@ -109,8 +101,7 @@ class ThreadingFuture(Future[T]):
             if self._result is not None:
                 raise queue.Full
             self._result = ThreadingFutureResult(exc_info=exc_info)
-            if self._waiter_count != 0:
-                self._condition.notify_all()
+            self._condition.notify_all()
 
 
 class ThreadingActor(Actor):


### PR DESCRIPTION
- Based from `179883aaca6bb1745f570eef9ba939b60dcc2b6f`.
- Added `is_completed()` to check if the future has had one of it's `set*()` methods called.
- If a `_get_hook` returns `None`, that will be considered the intended computed value and it will be cached into the `_get_hook_result` permanently.
- Of the 3 methods `set()`, `set_exception()`, and `set_get_hook()`, only one can be called for a given future instance and at most once. Further calls will raise `queue.Full`.