### PR TITLE
tomli has been integrated as "tomllib" in the standard library

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,12 @@
 """Pykka documentation build configuration file."""
 
 import pathlib
+import sys
 
-import tomli
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 project = "Pykka"
 author = "Stein Magnus Jodal and contributors"
@@ -10,7 +14,7 @@ copyright = f"2010-2025, {author}"  # noqa: A001
 
 pyproject_path = pathlib.Path(__file__).parent.parent / "pyproject.toml"
 with pyproject_path.open("rb") as fh:
-    pyproject = tomli.load(fh)
+    pyproject = tomllib.load(fh)
 release = pyproject["project"]["version"]
 version = ".".join(release.split(".")[:2])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     { include-group = "ruff" },
     { include-group = "tests" },
 ]
-docs = ["sphinx>=6.2.1", "sphinx_rtd_theme>=1.3.0", "tomli>=2.0.1"]
+docs = ["sphinx>=6.2.1", "sphinx_rtd_theme>=1.3.0", "tomli>=2.0.1 ; python_version < '3.11'"]
 mypy = ["mypy>=1.17.1"]
 pyright = ["pyright>=1.1.403"]
 ruff = ["ruff>=0.12.8"]


### PR DESCRIPTION
... from Python 3.11, then an external library is not even needed anymore