### PR TITLE
Only call future hook once, even if it returns None

### DIFF
--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -18,6 +18,10 @@ R = TypeVar("R")  # Result of Future.reduce()
 GetHookFunc: TypeAlias = Callable[[float | None], T]
 
 
+class _Unset:
+    pass
+
+
 class Future(Generic[T]):
     """A handle to a value which is available now or in the future.
 
@@ -28,12 +32,12 @@ class Future(Generic[T]):
     """
 
     _get_hook: GetHookFunc[T] | None
-    _get_hook_result: T | None
+    _get_hook_result: T | _Unset
 
     def __init__(self) -> None:
         super().__init__()
         self._get_hook = None
-        self._get_hook_result = None
+        self._get_hook_result = _Unset()
 
     def __repr__(self) -> str:
         return "<pykka.Future>"
@@ -64,7 +68,7 @@ class Future(Generic[T]):
         :return: encapsulated value if it is not an exception
         """
         if self._get_hook is not None:
-            if self._get_hook_result is None:
+            if isinstance(self._get_hook_result, _Unset):
                 self._get_hook_result = self._get_hook(timeout)
             return self._get_hook_result
         raise NotImplementedError

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -157,6 +157,18 @@ def test_future_supports_yield_from_syntax(
     assert run_async(get_value()) == 1
 
 
+def test_get_hook_is_only_called_once_even_if_result_is_none(
+    future: Future[int],
+    mocker: MockerFixture,
+) -> None:
+    hook_func = mocker.Mock(return_value=None)
+    future.set_get_hook(hook_func)
+
+    assert future.get(timeout=0) is None
+    assert future.get(timeout=0) is None
+    assert hook_func.call_count == 1
+
+
 def test_filter_excludes_items_not_matching_predicate(
     future: Future[Iterable[int]],
 ) -> None:


### PR DESCRIPTION
If a future's hook returned `None`, potentially after doing lots of expensive work, it would be called again and again every time the future was `.get()`-ed.