### PR TITLE
Only allow a single Future setter to be called

### DIFF
--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -79,6 +79,10 @@ class Future(Generic[T]):
     ) -> None:
         """Set the encapsulated value.
 
+        .. versionchanged:: 4.3
+            Calling :meth:`set` on a future that already has a get hook set now
+            raises an exception.
+
         :param value: the encapsulated value or nothing
         :type value: any object or :class:`None`
         :raise: an exception if set is called multiple times
@@ -98,6 +102,10 @@ class Future(Generic[T]):
         In other words, if you're calling :meth:`set_exception`, without any
         arguments, from an except block, the exception you're currently
         handling will automatically be set on the future.
+
+        .. versionchanged:: 4.3
+            Calling :meth:`set_exception` on a future that already has a
+            get hook set now raises an exception.
 
         :param exc_info: the encapsulated exception
         :type exc_info: three-tuple of (exc_class, exc_instance, traceback)

--- a/src/pykka/_future.py
+++ b/src/pykka/_future.py
@@ -116,6 +116,10 @@ class Future(Generic[T]):
 
         .. versionadded:: 1.2
 
+        .. versionchanged:: 4.3
+            Calling :meth:`set_get_hook` on a future that already has a
+            result set now raises an exception.
+
         :param func: called to produce return value of :meth:`get`
         :type func: function accepting a timeout value
         """

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -108,6 +108,8 @@ class ThreadingFuture(Future[T]):
         func: GetHookFunc[T],
     ) -> None:
         with self._condition:
+            if self._result is not None:
+                raise queue.Full
             super().set_get_hook(func)
             self._condition.notify_all()
 

--- a/src/pykka/_threading.py
+++ b/src/pykka/_threading.py
@@ -84,7 +84,7 @@ class ThreadingFuture(Future[T]):
         value: Any | None = None,
     ) -> None:
         with self._condition:
-            if self._result is not None:
+            if self._result is not None or self._get_hook is not None:
                 raise queue.Full
             self._result = ThreadingFutureResult(value=value)
             self._condition.notify_all()
@@ -98,7 +98,7 @@ class ThreadingFuture(Future[T]):
             exc_info = sys.exc_info()
 
         with self._condition:
-            if self._result is not None:
+            if self._result is not None or self._get_hook is not None:
                 raise queue.Full
             self._result = ThreadingFutureResult(exc_info=exc_info)
             self._condition.notify_all()

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import queue
 import sys
 import traceback
 import types
@@ -167,6 +168,17 @@ def test_get_hook_is_only_called_once_even_if_result_is_none(
     assert future.get(timeout=0) is None
     assert future.get(timeout=0) is None
     assert hook_func.call_count == 1
+
+
+def test_set_hook_is_not_allowed_on_future_with_result(
+    future: Future[int],
+) -> None:
+    future.set(123)
+
+    with pytest.raises(queue.Full):
+        future.set_get_hook(lambda timeout: 456)
+
+    assert future.get(timeout=0) == 123
 
 
 def test_filter_excludes_items_not_matching_predicate(

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -170,6 +170,37 @@ def test_get_hook_is_only_called_once_even_if_result_is_none(
     assert hook_func.call_count == 1
 
 
+def test_set_is_not_alloed_on_future_with_get_hook(
+    future: Future[int],
+    mocker: MockerFixture,
+) -> None:
+    hook_func = mocker.Mock(return_value=123)
+    future.set_get_hook(hook_func)
+
+    with pytest.raises(queue.Full):
+        future.set(456)
+
+    assert future.get(timeout=0) == 123
+    assert hook_func.call_count == 1
+
+
+def test_set_exception_is_not_allowed_on_future_with_get_hook(
+    future: Future[int],
+    mocker: MockerFixture,
+) -> None:
+    hook_func = mocker.Mock(return_value=123)
+    future.set_get_hook(hook_func)
+
+    try:
+        raise RuntimeError("failure")  # noqa: TRY301
+    except RuntimeError:
+        with pytest.raises(queue.Full):
+            future.set_exception()
+
+    assert future.get(timeout=0) == 123
+    assert hook_func.call_count == 1
+
+
 def test_set_hook_is_not_allowed_on_future_with_result(
     future: Future[int],
 ) -> None:


### PR DESCRIPTION
We already raised an exception if multiple calls to `.set()` and `.set_exception()` were done on a single future. Now, the same behavior applies to `.set_get_hook()`.

This may be a breaking change if you use `Future.set_get_hook()` directly. If you only use it indirectly via `Future.map()`, `.join()`, and `.reduce()`, there is no change, as these have always created new futures with the get hook, wrapping the futures with the results to transform.

Closes #235