### PR TITLE
Remove pykka.__version__

### DIFF
--- a/src/pykka/__init__.py
+++ b/src/pykka/__init__.py
@@ -1,6 +1,5 @@
 """Pykka is a Python implementation of the actor model."""
 
-import importlib.metadata as _importlib_metadata
 import logging as _logging
 
 from pykka._exceptions import ActorDeadError, Timeout
@@ -28,13 +27,5 @@ __all__ = [
     "get_all",
     "traversable",
 ]
-
-
-__version__: str
-try:
-    __version__ = _importlib_metadata.version(__name__)
-except _importlib_metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
 
 _logging.getLogger(__name__).addHandler(_logging.NullHandler())


### PR DESCRIPTION
Since Pykka now requires Python 3.10, `importlib.metadata.version("pykka")` is always available and a good replacement for `pykka.__version__`.